### PR TITLE
public new in ActorId

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,19 +29,20 @@ Think **Kafka+Microservices, but for Tokio tasks** instead of distributed system
 | Scope | In-process | In-process | Distributed |
 
 
-### Where it fits 
+### Where it fits
 
 Event-centric systems:
 
-- processing stock ticks, 
-- device signals, 
-- game events, telemetry pipelines. 
- 
+- System event processing (device monitoring, signals, inotify)
+- Data pipelines (sensor data, stock ticks, telemetry)
+- Game engines (entity systems, input handling)
+- Reactive architectures (event sourcing, CQRS)
+
 Not ideal for request-response APIs or RPC patterns.
 
 ### Why "Maiko"?
 
-**Maiko** (舞妓) are traditional Japanese performers known for their coordinated dances. Like maiko who respond to music and each other in harmony, Maiko actors coordinate through events in the Tokio runtime. 
+**Maiko** (舞妓) are traditional Japanese performers known for their coordinated dances. Like maiko who respond to music and each other in harmony, Maiko actors coordinate through events in the Tokio runtime.
 
 ---
 
@@ -136,7 +137,7 @@ For detailed documentation, see **[Core Concepts](doc/concepts.md)**.
 
 ## Test Harness
 
-Maiko includes a test harness (built on the monitoring API) for observing and asserting on event flow:
+Maiko includes a test harness for observing and asserting on event flow:
 
 ```rust
 #[tokio::test]

--- a/doc/advanced.md
+++ b/doc/advanced.md
@@ -52,6 +52,7 @@ let mut sup = Supervisor::new(config);
 | `channel_size` | 32 | Buffer size for actor event queues |
 | `max_events_per_tick` | 10 | Max events an actor processes before yielding |
 | `maintenance_interval` | 1s | How often broker cleans up closed channels |
+| `monitoring_channel_size` | 1024 | Buffer size used by "monitoring" feature |
 
 ## Design Philosophy
 
@@ -134,12 +135,5 @@ Start with defaults and tune based on profiling.
 
 ### Payload Size
 
-For large payloads, wrap in `Arc`:
-
-```rust
-#[derive(Event, Clone, Debug)]
-enum DataEvent {
-    LargePayload(Arc<Vec<u8>>),  // Cloning is cheap
-    SmallPayload(u32),           // Direct is fine
-}
-```
+Maiko can handle larger events efficently as each `Envelope` is wrapped in `Arc` before sending.
+It means there is no memory overhead while sending the same event to multiple actors.

--- a/maiko/CHANGELOG.md
+++ b/maiko/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+### Changed
+
+- `ActorId` has a public constructor now
+
 # [0.2.0](https://github.com/ddrcode/maiko/compare/v0.1.1...v0.2.0) (January 27th, 2026)
 
 ** Contains Breaking changes **

--- a/maiko/src/actor_id.rs
+++ b/maiko/src/actor_id.rs
@@ -31,7 +31,7 @@ use std::{hash::Hash, ops::Deref, sync::Arc};
 pub struct ActorId(Arc<str>);
 
 impl ActorId {
-    pub(crate) fn new(id: Arc<str>) -> Self {
+    pub fn new(id: Arc<str>) -> Self {
         Self(id)
     }
 


### PR DESCRIPTION
- `ActorId::new` is public now. Need for IPC (Charon case)
- Updated documentation