### PR TITLE
Implement actor introspection API for runtime observability

### DIFF
--- a/maiko/Cargo.toml
+++ b/maiko/Cargo.toml
@@ -24,6 +24,7 @@ macros = ["dep:maiko-macros"]
 serde = ["dep:serde", "dep:serde_json"]
 recorder = ["monitoring", "serde"]
 monitoring = []
+introspection = ["monitoring"]
 test-harness = ["monitoring"]
 
 [dependencies]

--- a/maiko/src/introspection/actor_info.rs
+++ b/maiko/src/introspection/actor_info.rs
@@ -1,0 +1,102 @@
+use std::time::SystemTime;
+
+use crate::ActorId;
+
+/// Runtime status of an actor.
+///
+/// Tracks the lifecycle state as observed by the introspection system.
+/// Status transitions follow this order:
+///
+/// ```text
+/// Registered → Idle → Processing → Idle → ... → Stopped
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum ActorStatus {
+    /// Actor has been added to the supervisor but the supervisor has not started yet.
+    Registered,
+    /// Actor is idle, waiting for events.
+    Idle,
+    /// Actor is currently processing an event inside `handle_event()`.
+    Processing,
+    /// Actor has exited (either normally or due to an error).
+    Stopped,
+}
+
+impl std::fmt::Display for ActorStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ActorStatus::Registered => write!(f, "registered"),
+            ActorStatus::Idle => write!(f, "idle"),
+            ActorStatus::Processing => write!(f, "processing"),
+            ActorStatus::Stopped => write!(f, "stopped"),
+        }
+    }
+}
+
+/// Runtime information about a single actor.
+///
+/// Obtained from [`Introspector::list_actors`](super::Introspector::list_actors)
+/// or [`Introspector::actor_info`](super::Introspector::actor_info).
+///
+/// # Queue Depth
+///
+/// `mailbox_depth` reflects the number of pending events in the actor's
+/// mailbox at the instant the snapshot was taken. Because actors run
+/// concurrently, this value may have changed by the time you read it.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ActorInfo {
+    /// The actor's unique identifier.
+    pub actor_id: ActorId,
+    /// Current lifecycle status.
+    pub status: ActorStatus,
+    /// Number of events currently pending in the actor's mailbox.
+    ///
+    /// Computed as `max_capacity - capacity` on the underlying channel sender.
+    /// This is a point-in-time snapshot and may be stale by the time you read it.
+    pub mailbox_depth: usize,
+    /// Total capacity of the actor's mailbox channel.
+    pub mailbox_capacity: usize,
+    /// Total number of events this actor has processed (via `handle_event`).
+    pub events_handled: u64,
+    /// Total number of errors encountered by this actor.
+    pub error_count: u64,
+}
+
+/// Point-in-time snapshot of the entire actor system.
+///
+/// Contains a timestamp and information about every registered actor.
+///
+/// # Example
+///
+/// ```ignore
+/// let snapshot = supervisor.introspection().snapshot();
+/// for actor in &snapshot.actors {
+///     println!("{}: {} (queue: {}/{})",
+///         actor.actor_id.name(),
+///         actor.status,
+///         actor.mailbox_depth,
+///         actor.mailbox_capacity,
+///     );
+/// }
+/// ```
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct SystemSnapshot {
+    /// Timestamp in nanoseconds since Unix epoch when the snapshot was taken.
+    pub timestamp: u64,
+    /// Information about all registered actors at the time of the snapshot.
+    pub actors: Vec<ActorInfo>,
+}
+
+impl SystemSnapshot {
+    /// Create a new snapshot with the current timestamp.
+    pub(crate) fn new(actors: Vec<ActorInfo>) -> Self {
+        let timestamp = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("SystemTime before Unix epoch")
+            .as_nanos() as u64;
+        Self { timestamp, actors }
+    }
+}

--- a/maiko/src/introspection/introspector.rs
+++ b/maiko/src/introspection/introspector.rs
@@ -1,0 +1,66 @@
+use std::sync::Arc;
+
+use crate::{ActorId, Event};
+
+use super::actor_info::{ActorInfo, SystemSnapshot};
+use super::shared_state::SharedState;
+
+/// Handle for querying runtime actor state.
+///
+/// Provides live introspection into the actor system, including:
+/// - Actor listing and individual lookups
+/// - Mailbox queue depths (queried live from channel senders)
+/// - Event and error counters
+/// - Point-in-time system snapshots
+///
+/// # Example
+///
+/// ```ignore
+/// let introspector = supervisor.introspection();
+///
+/// // List all actors
+/// for actor in introspector.list_actors() {
+///     println!("{}: {} (queue: {}/{})",
+///         actor.actor_id.name(),
+///         actor.status,
+///         actor.mailbox_depth,
+///         actor.mailbox_capacity,
+///     );
+/// }
+///
+/// // Snapshot the entire system
+/// let snapshot = introspector.snapshot();
+/// println!("System has {} actors at t={}", snapshot.actors.len(), snapshot.timestamp);
+/// ```
+pub struct Introspector<E: Event> {
+    pub(crate) state: Arc<SharedState<E>>,
+}
+
+impl<E: Event> Introspector<E> {
+    pub(crate) fn new(state: Arc<SharedState<E>>) -> Self {
+        Self { state }
+    }
+
+    /// List all registered actors with their current status and queue depths.
+    ///
+    /// Queue depths are queried live from the underlying channel senders
+    /// and reflect the state at the instant of the call.
+    pub fn list_actors(&self) -> Vec<ActorInfo> {
+        self.state.list_actors()
+    }
+
+    /// Get runtime info for a specific actor.
+    ///
+    /// Returns `None` if the actor has not been registered.
+    pub fn actor_info(&self, actor_id: &ActorId) -> Option<ActorInfo> {
+        self.state.actor_info(actor_id)
+    }
+
+    /// Take a point-in-time snapshot of the entire actor system.
+    ///
+    /// The snapshot includes a timestamp and information about every
+    /// registered actor, including live queue depths.
+    pub fn snapshot(&self) -> SystemSnapshot {
+        SystemSnapshot::new(self.state.list_actors())
+    }
+}

--- a/maiko/src/introspection/mod.rs
+++ b/maiko/src/introspection/mod.rs
@@ -1,0 +1,50 @@
+//! Actor introspection API for runtime observability.
+//!
+//! Enable with the `introspection` feature:
+//!
+//! ```toml
+//! [dependencies]
+//! maiko = { version = "0.2", features = ["introspection"] }
+//! ```
+//!
+//! # Overview
+//!
+//! The introspection system provides live visibility into actor state:
+//! - List all registered actors and their current status
+//! - Query mailbox queue depths in real time
+//! - Track event throughput and error counts
+//! - Take point-in-time system snapshots
+//!
+//! Built on the existing [`monitoring`](crate::monitoring) system using the
+//! observer pattern.
+//!
+//! # Example
+//!
+//! ```ignore
+//! let mut sup = Supervisor::<MyEvent>::default();
+//! sup.add_actor("worker", |ctx| Worker::new(ctx), &[DefaultTopic])?;
+//!
+//! sup.start().await?;
+//!
+//! // Query actor state
+//! let actors = sup.introspection().list_actors();
+//! for actor in &actors {
+//!     println!("{}: {} (queue: {}/{})",
+//!         actor.actor_id.name(),
+//!         actor.status,
+//!         actor.mailbox_depth,
+//!         actor.mailbox_capacity,
+//!     );
+//! }
+//!
+//! // Take a system snapshot
+//! let snapshot = sup.introspection().snapshot();
+//! ```
+
+mod actor_info;
+mod introspector;
+pub(crate) mod shared_state;
+pub(crate) mod state_tracker;
+
+pub use actor_info::{ActorInfo, ActorStatus, SystemSnapshot};
+pub use introspector::Introspector;

--- a/maiko/src/introspection/shared_state.rs
+++ b/maiko/src/introspection/shared_state.rs
@@ -1,0 +1,108 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use tokio::sync::mpsc::Sender;
+
+use crate::{ActorId, Envelope, Event};
+
+use super::actor_info::{ActorInfo, ActorStatus};
+
+/// Per-actor state entry stored in the shared introspection state.
+pub(crate) struct ActorEntry<E: Event> {
+    pub status: ActorStatus,
+    pub events_handled: u64,
+    pub error_count: u64,
+    /// Cloned sender pointing to the actor's mailbox channel.
+    /// Used to query `capacity()` / `max_capacity()` for queue depth.
+    pub sender: Sender<Arc<Envelope<E>>>,
+}
+
+/// Internal shared state for the introspection system.
+///
+/// Written to by both:
+/// - `Supervisor::register_actor` — stores the mailbox `Sender` for queue depth queries
+/// - `StateTracker` monitor — updates status, event count, and error count via observer callbacks
+///
+/// Read by `Introspector` to produce `ActorInfo` and `SystemSnapshot`.
+pub(crate) struct SharedState<E: Event> {
+    actors: Mutex<HashMap<ActorId, ActorEntry<E>>>,
+}
+
+impl<E: Event> SharedState<E> {
+    pub fn new() -> Self {
+        Self {
+            actors: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Register a new actor with its mailbox sender.
+    ///
+    /// Called by `Supervisor::register_actor` when the `introspection` feature is enabled.
+    pub fn register_actor(&self, actor_id: ActorId, sender: Sender<Arc<Envelope<E>>>) {
+        let mut actors = self.actors.lock().expect("SharedState lock poisoned");
+        actors.insert(
+            actor_id,
+            ActorEntry {
+                status: ActorStatus::Registered,
+                events_handled: 0,
+                error_count: 0,
+                sender,
+            },
+        );
+    }
+
+    /// Update the status of an actor.
+    pub fn set_status(&self, actor_id: &ActorId, status: ActorStatus) {
+        let mut actors = self.actors.lock().expect("SharedState lock poisoned");
+        if let Some(entry) = actors.get_mut(actor_id) {
+            entry.status = status;
+        }
+    }
+
+    /// Increment the events_handled counter for an actor.
+    pub fn increment_handled(&self, actor_id: &ActorId) {
+        let mut actors = self.actors.lock().expect("SharedState lock poisoned");
+        if let Some(entry) = actors.get_mut(actor_id) {
+            entry.events_handled += 1;
+        }
+    }
+
+    /// Increment the error_count counter for an actor.
+    pub fn increment_errors(&self, actor_id: &ActorId) {
+        let mut actors = self.actors.lock().expect("SharedState lock poisoned");
+        if let Some(entry) = actors.get_mut(actor_id) {
+            entry.error_count += 1;
+        }
+    }
+
+    /// Get info for all registered actors with live queue depth.
+    pub fn list_actors(&self) -> Vec<ActorInfo> {
+        let actors = self.actors.lock().expect("SharedState lock poisoned");
+        actors
+            .iter()
+            .map(|(id, entry)| Self::build_actor_info(id, entry))
+            .collect()
+    }
+
+    /// Get info for a specific actor.
+    pub fn actor_info(&self, actor_id: &ActorId) -> Option<ActorInfo> {
+        let actors = self.actors.lock().expect("SharedState lock poisoned");
+        actors
+            .get(actor_id)
+            .map(|entry| Self::build_actor_info(actor_id, entry))
+    }
+
+    /// Build an `ActorInfo` from an entry, querying live queue depth.
+    fn build_actor_info(actor_id: &ActorId, entry: &ActorEntry<E>) -> ActorInfo {
+        let max_capacity = entry.sender.max_capacity();
+        let remaining_capacity = entry.sender.capacity();
+        ActorInfo {
+            actor_id: actor_id.clone(),
+            status: entry.status.clone(),
+            mailbox_depth: max_capacity - remaining_capacity,
+            mailbox_capacity: max_capacity,
+            events_handled: entry.events_handled,
+            error_count: entry.error_count,
+        }
+    }
+}

--- a/maiko/src/introspection/state_tracker.rs
+++ b/maiko/src/introspection/state_tracker.rs
@@ -1,0 +1,43 @@
+use std::sync::Arc;
+
+use crate::{ActorId, Envelope, Event, Topic};
+use crate::monitoring::Monitor;
+
+use super::actor_info::ActorStatus;
+use super::shared_state::SharedState;
+
+/// A [`Monitor`] implementation that tracks actor state for introspection.
+///
+/// Observes lifecycle callbacks and updates the shared introspection state:
+/// - `on_event_delivered` → status becomes `Processing`
+/// - `on_event_handled` → status becomes `Idle`, events_handled incremented
+/// - `on_error` → error_count incremented
+/// - `on_actor_stop` → status becomes `Stopped`
+pub(crate) struct StateTracker<E: Event> {
+    state: Arc<SharedState<E>>,
+}
+
+impl<E: Event> StateTracker<E> {
+    pub fn new(state: Arc<SharedState<E>>) -> Self {
+        Self { state }
+    }
+}
+
+impl<E: Event, T: Topic<E>> Monitor<E, T> for StateTracker<E> {
+    fn on_event_delivered(&self, _envelope: &Envelope<E>, _topic: &T, receiver: &ActorId) {
+        self.state.set_status(receiver, ActorStatus::Processing);
+    }
+
+    fn on_event_handled(&self, _envelope: &Envelope<E>, _topic: &T, receiver: &ActorId) {
+        self.state.set_status(receiver, ActorStatus::Idle);
+        self.state.increment_handled(receiver);
+    }
+
+    fn on_error(&self, _err: &str, actor_id: &ActorId) {
+        self.state.increment_errors(actor_id);
+    }
+
+    fn on_actor_stop(&self, actor_id: &ActorId) {
+        self.state.set_status(actor_id, ActorStatus::Stopped);
+    }
+}

--- a/maiko/src/lib.rs
+++ b/maiko/src/lib.rs
@@ -111,6 +111,7 @@
 //! - **`test-harness`** - Test utilities for recording, spying, and asserting on event flow (enables `monitoring`)
 //! - **`serde`** - JSON serialization support (e.g. `Supervisor::to_json()`)
 //! - **`recorder`** - Built-in `Recorder` monitor for writing events to JSON Lines files (enables `monitoring` and `serde`)
+//! - **`introspection`** - Runtime actor introspection: list actors, query status, mailbox depths, snapshots (enables `monitoring`)
 //!
 //! ## Examples
 //!
@@ -150,6 +151,10 @@ pub mod monitoring;
 #[cfg(feature = "monitoring")]
 #[cfg_attr(docsrs, doc(cfg(feature = "monitoring")))]
 pub mod monitors;
+
+#[cfg(feature = "introspection")]
+#[cfg_attr(docsrs, doc(cfg(feature = "introspection")))]
+pub mod introspection;
 
 pub use actor::Actor;
 pub use actor_builder::ActorBuilder;

--- a/maiko/tests/introspection.rs
+++ b/maiko/tests/introspection.rs
@@ -1,0 +1,106 @@
+#![cfg(feature = "introspection")]
+
+use maiko::{Actor, ActorId, Envelope, Event, Result, Subscribe, Supervisor, DefaultTopic};
+use std::sync::Arc;
+use tokio::sync::Barrier;
+
+#[derive(Event, Debug, Clone)]
+enum TestEvent {
+    #[allow(dead_code)]
+    Sensor(f64),
+}
+
+
+struct DummyActor;
+impl Actor for DummyActor {
+    type Event = TestEvent;
+    async fn handle_event(&mut self, _: &Envelope<Self::Event>) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn test_introspection_list_actors() {
+    let mut sup = Supervisor::<TestEvent>::default();
+    sup.add_actor("a", |_| DummyActor, Subscribe::none()).unwrap();
+    sup.add_actor("b", |_| DummyActor, Subscribe::none()).unwrap();
+
+    sup.start().await.unwrap();
+
+    // Give a moment for registration to settle if needed, though they are registered synchronously
+    
+    let actors = sup.introspection().list_actors();
+    assert_eq!(actors.len(), 2);
+    
+    let names: Vec<_> = actors.iter().map(|a| a.actor_id.name()).collect();
+    assert!(names.contains(&"a"));
+    assert!(names.contains(&"b"));
+}
+
+#[tokio::test]
+async fn test_introspection_actor_info() {
+    let mut sup = Supervisor::<TestEvent>::default();
+    let id = sup.add_actor("my_actor", |_| DummyActor, Subscribe::none()).unwrap();
+
+    sup.start().await.unwrap();
+
+    let info = sup.introspection().actor_info(&id).expect("Actor not found");
+    assert_eq!(info.actor_id.name(), "my_actor");
+    assert_eq!(info.mailbox_depth, 0);
+}
+
+#[tokio::test]
+async fn test_introspection_snapshot() {
+    let mut sup = Supervisor::<TestEvent>::default();
+    sup.add_actor("a", |_| DummyActor, Subscribe::none()).unwrap();
+
+    let snap = sup.introspection().snapshot();
+    assert!(snap.timestamp > 0);
+    assert_eq!(snap.actors.len(), 1);
+    assert_eq!(snap.actors[0].actor_id.name(), "a");
+}
+
+#[tokio::test]
+async fn test_introspection_queue_depth() {
+    struct BlockingActor {
+        barrier: Arc<Barrier>,
+    }
+
+    impl Actor for BlockingActor {
+        type Event = TestEvent;
+        async fn handle_event(&mut self, _: &Envelope<Self::Event>) -> Result<()> {
+            self.barrier.wait().await;
+            Ok(())
+        }
+    }
+
+    let mut sup = Supervisor::<TestEvent>::default();
+    let barrier = Arc::new(Barrier::new(2)); // Wait for test + actor
+    let b = barrier.clone();
+    
+    // Register actor
+    // The topic needs to be explicitly provided. 
+    // DefaultTopic works if we use DefaultTopic in Supervisor, but we need to subscribe to something.
+    // If we use DefaultTopic, we can just use `&[DefaultTopic]`.
+    sup.add_actor("blocker", move |_| BlockingActor { barrier: b }, &[DefaultTopic]).unwrap();
+
+    sup.start().await.unwrap();
+
+    // Send an event to trigger the barrier wait in the actor
+    sup.send(TestEvent::Sensor(1.0)).await.unwrap();
+
+    // Send more events to fill the queue
+    sup.send(TestEvent::Sensor(2.0)).await.unwrap();
+    sup.send(TestEvent::Sensor(3.0)).await.unwrap();
+
+    // Give a moment for the broker to dispatch
+    tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+
+    let info = sup.introspection().actor_info(&ActorId::new("blocker".into())).unwrap();
+    
+    assert!(info.mailbox_depth > 0, "Queue depth should be positive, got {}", info.mailbox_depth);
+    assert_eq!(info.status, maiko::introspection::ActorStatus::Processing);
+
+    // Unblock
+    barrier.wait().await;
+}


### PR DESCRIPTION
This PR implements (#26). 

Adds focused introspection tests to improve visibility into the actor system and test harness: it introduces the new test suite in introspection.rs, exercises actor state tracking and monitoring functionality, and includes small supporting refactors to make introspection APIs more testable. These changes increase test coverage, surface subtle concurrency issues for future fixes,