### PR TITLE
supervisor to consume itself on stop/join [#43]

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -223,21 +223,24 @@ See [Advanced Topics - Per-Actor Config](advanced.md#per-actor-config) for detai
 
 ### Runtime Control
 
+The terminal methods (`run`, `join`, `stop`) consume the supervisor, preventing
+use-after-shutdown at compile time.
+
 ```rust
-// Start all actors (non-blocking)
+// Send events before shutdown (Supervisor as actor)
+sup.send(MyEvent::Data(42)).await?;
+
+// Start all actors (non-blocking) — borrows &mut self
 sup.start().await?;
 
-// Wait for completion
+// Wait for completion — consumes the supervisor
 sup.join().await?;
 
-// Or combine both
+// Or combine start + join in one call
 sup.run().await?;
 
-// Graceful shutdown
+// Graceful shutdown — consumes the supervisor
 sup.stop().await?;
-
-// Send events from outside (Supervisor as actor)
-sup.send(MyEvent::Data(42)).await?;
 ```
 
 ## StepAction

--- a/maiko/CHANGELOG.md
+++ b/maiko/CHANGELOG.md
@@ -21,6 +21,7 @@
 - **Breaking:** `correlation_id` renamed to `parent_id` throughout
 - **Breaking:** `Error::IOError` renamed to `IoError`
 - **Breaking:** `Context::send_envelope()` made private
+- **Breaking:** `Supervisor::run()`, `join()`, `stop()` now consume `self`, preventing use-after-shutdown ([#43])
 - Improved documentation with examples
 
 ### Removed
@@ -28,6 +29,8 @@
 - **Breaking:** `Context::send_with_correlation()` (use `send_child_event()` instead)
 - **Breaking:** `Deref` impls on `Envelope` (use `event()`) and `ActorId` (use `as_str()`)
 - **Breaking:** Deprecated methods removed from `Config`
+
+[#43]: https://github.com/maiko-rs/maiko/issues/43
 
 ---
 

--- a/maiko/examples/backpressure.rs
+++ b/maiko/examples/backpressure.rs
@@ -215,7 +215,6 @@ async fn run() -> maiko::Result {
     sup.send(Event::Start(1000)).await?;
     sup.join().await?;
     println!("Elapsed: {:?}", start.elapsed());
-    sup.stop().await?;
     Ok(())
 }
 


### PR DESCRIPTION
`stop`, `join` and `run` methods of supervisor consume `self` - fixes #43 