### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,5 +30,10 @@ jobs:
           tool: cargo-spellcheck
           fallback: none
 
+      - name: Install taplo
+        uses: taiki-e/install-action@v2
+        with:
+          tool: taplo-cli
+
       - name: Run CI
         run: just ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,16 +24,11 @@ jobs:
       - name: Install just
         uses: extractions/setup-just@v2
 
-      - name: Install LLVM/libclang (for cargo-spellcheck)
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends llvm-dev libclang-dev clang
-
       - name: Install cargo-spellcheck
-        run: |
-          export LLVM_CONFIG_PATH="$(command -v llvm-config)"
-          export LIBCLANG_PATH="$(llvm-config --libdir)"
-          cargo install --locked cargo-spellcheck
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-spellcheck
+          fallback: none
 
       - name: Run CI
         run: just ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   pull_request:
+    types: [opened, synchronize, ready_for_review]
   workflow_dispatch:
 
 env:
@@ -9,6 +10,7 @@ env:
 
 jobs:
   ci:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -22,8 +24,16 @@ jobs:
       - name: Install just
         uses: extractions/setup-just@v2
 
+      - name: Install LLVM/libclang (for cargo-spellcheck)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends llvm-dev libclang-dev clang
+
       - name: Install cargo-spellcheck
-        run: cargo install cargo-spellcheck
+        run: |
+          export LLVM_CONFIG_PATH="$(command -v llvm-config)"
+          export LIBCLANG_PATH="$(llvm-config --libdir)"
+          cargo install --locked cargo-spellcheck
 
       - name: Run CI
         run: just ci

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,6 @@
 [workspace]
+members  = ["maiko", "maiko-macros"]
 resolver = "2"
-members = [
-  "maiko",
-  "maiko-macros",
-]
 
-[workspace.metadata.spellcheck]
-config = "spellcheck.toml"
-
+  [workspace.metadata.spellcheck]
+  config = "spellcheck.toml"

--- a/justfile
+++ b/justfile
@@ -5,6 +5,7 @@ default: check
 check:
     cargo fmt --all -- --check
     cargo clippy --workspace --all-targets --all-features -- -D warnings
+    taplo fmt --check
 
 # Full CI: format, lint, test, spell, build examples
 ci: check test spell build
@@ -12,6 +13,7 @@ ci: check test spell build
 # Format code
 fmt:
     cargo fmt --all
+    taplo fmt
 
 # Run all tests
 test:

--- a/maiko-macros/Cargo.toml
+++ b/maiko-macros/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
-name = "maiko-macros"
-version = "0.3.1"
-edition = "2024"
-rust-version = "1.85"
-description = "Procedural macros for the Maiko actor runtime"
-authors = ["David de Rosier <ddrcode@gmail.com>"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/maiko-rs/maiko"
-keywords = ["maiko", "actor", "macro", "derive"]
-categories = ["development-tools::procedural-macro-helpers"]
-homepage = "https://github.com/maiko-rs/maiko"
+authors       = ["David de Rosier <ddrcode@gmail.com>"]
+categories    = ["development-tools::procedural-macro-helpers"]
+description   = "Procedural macros for the Maiko actor runtime"
 documentation = "https://docs.rs/maiko-macros"
-readme = "README.md"
+edition       = "2024"
+homepage      = "https://github.com/maiko-rs/maiko"
+keywords      = ["actor", "derive", "macro", "maiko"]
+license       = "MIT OR Apache-2.0"
+name          = "maiko-macros"
+readme        = "README.md"
+repository    = "https://github.com/maiko-rs/maiko"
+rust-version  = "1.85"
+version       = "0.3.1"
 
 [lib]
 proc-macro = true
 
 [dependencies]
 quote = "1.0"
-syn = "2.0"
+syn   = "2.0"

--- a/maiko/Cargo.toml
+++ b/maiko/Cargo.toml
@@ -1,71 +1,71 @@
 [package]
-name = "maiko"
-version = "0.3.1"
-edition = "2024"
-rust-version = "1.85"
-description = "Lightweight event-driven actor runtime with topic-based pub/sub for Tokio"
-authors = ["David de Rosier <ddrcode@gmail.com>"]
-license = "MIT OR Apache-2.0"
-keywords = ["actor", "pubsub", "tokio", "event-driven", "message-passing"]
-categories = ["asynchronous", "concurrency"]
-repository = "https://github.com/maiko-rs/maiko"
-homepage = "https://github.com/maiko-rs/maiko"
+authors       = ["David de Rosier <ddrcode@gmail.com>"]
+categories    = ["asynchronous", "concurrency"]
+description   = "Lightweight event-driven actor runtime with topic-based pub/sub for Tokio"
 documentation = "https://docs.rs/maiko"
-readme = "README.md"
-exclude = [".gitignore", ".github/"]
+edition       = "2024"
+exclude       = [".github/", ".gitignore"]
+homepage      = "https://github.com/maiko-rs/maiko"
+keywords      = ["actor", "event-driven", "message-passing", "pubsub", "tokio"]
+license       = "MIT OR Apache-2.0"
+name          = "maiko"
+readme        = "README.md"
+repository    = "https://github.com/maiko-rs/maiko"
+rust-version  = "1.85"
+version       = "0.3.1"
 
-[package.metadata.docs.rs]
-all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
+  [package.metadata.docs.rs]
+  all-features = true
+  rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = ["macros"]
-macros = ["dep:maiko-macros"]
-serde = ["dep:serde", "dep:serde_json"]
-recorder = ["monitoring", "serde"]
-monitoring = []
+default      = ["macros"]
+macros       = ["dep:maiko-macros"]
+monitoring   = []
+recorder     = ["monitoring", "serde"]
+serde        = ["dep:serde", "dep:serde_json"]
 test-harness = ["monitoring"]
 
 [dependencies]
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 maiko-macros = { version = "=0.3.1", optional = true, path = "../maiko-macros/" }
-serde = { version = "1.0", features = ["derive", "rc"], optional = true }
-serde_json = { version = "1.0", optional = true }
-thiserror = "2.0"
-tokio = {version="1.49", features=["macros", "rt", "rt-multi-thread", "time"]}
+serde        = { version = "1.0", features = ["derive", "rc"], optional = true }
+serde_json   = { version = "1.0", optional = true }
+thiserror    = "2.0"
+tokio        = { version = "1.49", features = ["macros", "rt", "rt-multi-thread", "time"] }
 tokio-stream = "0.1"
-tracing = "0.1"
-uuid = { version = "1.20", features = ["v4"] }
+tracing      = "0.1"
+uuid         = { version = "1.20", features = ["v4"] }
 
 [dev-dependencies]
-criterion = "0.8.2"
-getrandom = "0.4"
+criterion          = "0.8.2"
+getrandom          = "0.4"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
 
 [[example]]
-name = "hello-world"
+name              = "hello-world"
 required-features = ["default"]
 
 [[example]]
-name = "pingpong"
+name              = "pingpong"
 required-features = ["default"]
 
 [[example]]
-name = "guesser"
+name              = "guesser"
 required-features = ["default"]
 
 [[example]]
-name = "monitoring"
+name              = "monitoring"
 required-features = ["monitoring"]
 
 [[example]]
-name = "arbitrage"
+name              = "arbitrage"
 required-features = ["default", "test-harness"]
 
 [[example]]
 name = "backpressure"
 
 [[bench]]
-name = "broker_subscriber_lookup"
 harness = false
-path = "benches/broker_subscriber_lookup.rs"
+name    = "broker_subscriber_lookup"
+path    = "benches/broker_subscriber_lookup.rs"

--- a/taplo.toml
+++ b/taplo.toml
@@ -1,0 +1,9 @@
+include = ["**/Cargo.toml", "Cargo.toml"]
+
+[formatting]
+align_entries         = true
+column_width          = 120
+indent_tables         = true
+reorder_arrays        = true
+reorder_keys          = true
+reorder_inline_tables = false


### PR DESCRIPTION
Addresses #106 by 
* fixing CI failure.
* adjusting events on which CI runs.

### Suggestions
- use [`nextest`](https://nexte.st/), it's much faster that simply `cargo test`. 
- use [`taplo`](https://taplo.tamasfe.dev/) to introduce unified formatting also for `toml` files.

If you like any (or both) of these suggestion, I will add them to this PR as separate commits.