### PR TITLE
Benches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,62 @@
 version = 4
 
 [[package]]
+name = "actix"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de7fa236829ba0841304542f7614c42b80fca007455315c45c785ccfa873a85b"
+dependencies = [
+ "actix-macros",
+ "actix-rt",
+ "actix_derive",
+ "bitflags",
+ "bytes",
+ "crossbeam-channel",
+ "futures-core",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "actix-macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "actix-rt"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92589714878ca59a7626ea19734f0e07a6a875197eec751bb5d3f99e64998c63"
+dependencies = [
+ "futures-core",
+ "tokio",
+]
+
+[[package]]
+name = "actix_derive"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6ac1e58cded18cb28ddc17143c4dea5345b3ad575e14f32f66e4054a56eb271"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -39,6 +95,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,10 +118,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "bon"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97493a391b4b18ee918675fb8663e53646fd09321c58b46afa04e8ce2499c869"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2af3eac944c12cdf4423eab70d310da0a8e5851a18ffb192c0a5e3f7ae1663"
+dependencies = [
+ "darling",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cast"
@@ -166,6 +262,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,6 +302,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,10 +363,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -221,10 +391,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -238,10 +467,16 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -282,6 +517,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -306,6 +547,12 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
@@ -363,6 +610,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,10 +628,12 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 name = "maiko"
 version = "0.3.1"
 dependencies = [
+ "actix",
  "criterion",
  "futures-util",
  "getrandom 0.4.1",
  "maiko-macros",
+ "ractor",
  "serde",
  "serde_json",
  "thiserror",
@@ -399,6 +657,17 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mio"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys",
+]
 
 [[package]]
 name = "num-traits"
@@ -429,6 +698,29 @@ checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
 ]
 
 [[package]]
@@ -506,6 +798,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "ractor"
+version = "0.15.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a64ac8ba2e8d71b25c55ab7acafc481ae4c9175f3ee8f7c36b66c4cad369bb5"
+dependencies = [
+ "async-trait",
+ "bon",
+ "dashmap",
+ "futures",
+ "js-sys",
+ "once_cell",
+ "strum",
+ "tokio",
+ "tokio_with_wasm",
+ "tracing",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
 name = "rayon"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -523,6 +836,15 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -568,6 +890,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -634,6 +962,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -689,8 +1077,16 @@ version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
  "tokio-macros",
+ "tracing",
+ "windows-sys",
 ]
 
 [[package]]
@@ -713,6 +1109,43 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio_with_wasm"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34e40fbbbd95441133fe9483f522db15dbfd26dc636164ebd8f2dd28759a6aa6"
+dependencies = [
+ "js-sys",
+ "tokio",
+ "tokio_with_wasm_proc",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "tokio_with_wasm_proc"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d01145a2c788d6aae4cd653afec1e8332534d7d783d01897cefcafe4428de992"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -791,6 +1224,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -819,6 +1258,20 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -892,6 +1345,16 @@ name = "web-sys"
 version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/justfile
+++ b/justfile
@@ -55,3 +55,13 @@ clean:
 # Watch and run tests on changes (requires bacon)
 watch:
     bacon test
+
+# Check if `uv` is installed. See installation instructions https://docs.astral.sh/uv/getting-started/installation/
+check-uv:
+    @if ! command -v uv >/dev/null 2>&1; then echo "Requires \`uv\`. See installation instructions https://docs.astral.sh/uv/getting-started/installation/"; exit 1; fi
+
+# Run Actor->Broker->Actor transport benchmark and print throughput matrix.
+# Print throughput matrix (messages/sec) from Criterion estimates.
+bench-a2a: check-uv
+    cargo bench -p maiko --bench actor_to_actor_transport_maiko -- --noplot
+    uv run --project scripts scripts/bench_a2a_matrix.py

--- a/justfile
+++ b/justfile
@@ -65,3 +65,10 @@ check-uv:
 bench-a2a: check-uv
     cargo bench -p maiko --bench actor_to_actor_transport_maiko -- --noplot
     uv run --project scripts scripts/bench_a2a_matrix.py
+
+# Run all Actor->Actor transport benches, then compare throughput across frameworks.
+bench-a2a-compare: check-uv
+    cargo bench --profile bench -p maiko --bench actor_to_actor_transport_maiko -- --noplot
+    cargo bench --profile bench -p maiko --bench actor_to_actor_transport_actix -- --noplot
+    cargo bench --profile bench -p maiko --bench actor_to_actor_transport_ractor -- --noplot
+    uv run --project scripts scripts/bench_a2a_compare.py

--- a/maiko/Cargo.toml
+++ b/maiko/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 authors       = ["David de Rosier <ddrcode@gmail.com>"]
+autobenches   = false
 categories    = ["asynchronous", "concurrency"]
 description   = "Lightweight event-driven actor runtime with topic-based pub/sub for Tokio"
 documentation = "https://docs.rs/maiko"
@@ -38,8 +39,10 @@ tracing      = "0.1"
 uuid         = { version = "1.20", features = ["v4"] }
 
 [dev-dependencies]
+actix              = "0.13"
 criterion          = "0.8.2"
 getrandom          = "0.4"
+ractor             = { version = "0.15", features = ["async-trait"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
 
 [[example]]
@@ -71,7 +74,16 @@ name    = "broker_subscriber_lookup"
 path    = "benches/broker_subscriber_lookup.rs"
 
 [[bench]]
-name = "actor_to_actor_transport_maiko"
 harness = false
-path = "benches/actor_to_actor_transport_maiko.rs"
+name    = "actor_to_actor_transport_maiko"
+path    = "benches/actor_to_actor_transport_maiko.rs"
 
+[[bench]]
+harness = false
+name    = "actor_to_actor_transport_actix"
+path    = "benches/actor_to_actor_transport_actix.rs"
+
+[[bench]]
+harness = false
+name    = "actor_to_actor_transport_ractor"
+path    = "benches/actor_to_actor_transport_ractor.rs"

--- a/maiko/Cargo.toml
+++ b/maiko/Cargo.toml
@@ -69,3 +69,9 @@ name = "backpressure"
 harness = false
 name    = "broker_subscriber_lookup"
 path    = "benches/broker_subscriber_lookup.rs"
+
+[[bench]]
+name = "actor_to_actor_transport_maiko"
+harness = false
+path = "benches/actor_to_actor_transport_maiko.rs"
+

--- a/maiko/benches/COMPARISON.md
+++ b/maiko/benches/COMPARISON.md
@@ -1,0 +1,139 @@
+# Actor-to-Actor Comparison
+
+This directory contains three comparative actor-to-actor transport benchmarks:
+
+- `actor_to_actor_transport_maiko.rs`
+- `actor_to_actor_transport_actix.rs`
+- `actor_to_actor_transport_ractor.rs`
+
+They all benchmark the same matrix:
+
+- message counts: `1_000`, `10_000`, `100_000`
+- payload sizes: `32B`, `256B`, `1KiB`, `4KiB`
+
+Criterion reports throughput in messages/sec.
+
+## Important framing
+
+This comparison is useful, but it is not perfectly apples-to-apples.
+
+`actix` and `ractor` are being exercised here as direct actor-to-actor transport systems. Maiko is not. Maiko routes messages through a broker, which means delivery is fundamentally a two-step path:
+
+1. producer -> broker
+2. broker -> subscriber
+
+That architectural choice is deliberate. It gives Maiko topic-based routing, looser coupling, and a more detached event-driven model, but it also means Maiko should not be expected to compete with direct-message runtimes on raw actor-to-actor throughput.
+
+Relatedly, Maiko is unlikely to reach `1M` events/sec in this style of benchmark, and that is not a project goal. Maiko is optimized primarily for ergonomics and a detached architecture. Pure transport performance is secondary.
+
+## How to run
+
+Run the full comparison from the repository root:
+
+```sh
+just bench-a2a-compare
+```
+
+That target executes:
+
+```sh
+cargo bench --profile bench -p maiko --bench actor_to_actor_transport_maiko -- --noplot
+cargo bench --profile bench -p maiko --bench actor_to_actor_transport_actix -- --noplot
+cargo bench --profile bench -p maiko --bench actor_to_actor_transport_ractor -- --noplot
+uv run --project scripts scripts/bench_a2a_compare.py
+```
+
+If you want to run the benches individually:
+
+```sh
+cargo bench --profile bench -p maiko --bench actor_to_actor_transport_maiko -- --noplot
+cargo bench --profile bench -p maiko --bench actor_to_actor_transport_actix -- --noplot
+cargo bench --profile bench -p maiko --bench actor_to_actor_transport_ractor -- --noplot
+```
+
+## Backpressure notes
+
+Backpressure matters here because Maiko's transport semantics are intentionally bounded and blocking under load. A comparison that ignores that entirely for the other runtimes is easier to implement, but it stops being a like-for-like transport comparison.
+
+### Maiko
+
+Maiko's benchmark uses real backpressure:
+
+- the producer sends via `Context::send(...).await`
+- the payload topic uses `OverflowPolicy::Block`
+
+That means the producer naturally waits when downstream capacity is exhausted.
+
+### Actix
+
+Actix also uses an explicit backpressure path in this comparison:
+
+- the producer sends via `Addr::send(...).await`
+- the consumer mailbox is explicitly bounded with `ctx.set_mailbox_capacity(MAILBOX_CAPACITY)`
+
+This is the closest Actix analogue to Maiko's blocking send semantics. It is not a perfect apples-to-apples mapping, because Actix `send` is request/response-oriented and carries reply-channel overhead even when the result type is `()`, but it does provide actual capacity-coupled waiting.
+
+### Ractor
+
+No backpressure is implemented in the `ractor` benchmark.
+
+The benchmark currently uses `ActorRef::send_message(...)`, which is a simple push path with no await-based mailbox backpressure. We explored replacing it with factory-based admission control, but that path appears substantially more cumbersome than the other two implementations and is not strictly necessary for keeping the comparative benchmark useful. Because of that, the `ractor` benchmark intentionally remains a simpler no-backpressure transport benchmark for now.
+
+In short:
+
+- Maiko: backpressure enabled
+- Actix: backpressure enabled
+- Ractor: backpressure intentionally not implemented
+
+## Example results
+
+These are example comparison results from one benchmark run.
+
+### Absolute throughput
+
+```text
+╭─────────────┬───────────────┬───────────┬───────────┬───────────┬───────────╮
+│   Framework │   N \ Payload │       32B │      256B │      1KiB │      4KiB │
+├─────────────┼───────────────┼───────────┼───────────┼───────────┼───────────┤
+│       maiko │         1,000 │   813,976 │   822,254 │   773,352 │   720,358 │
+│       maiko │        10,000 │   812,887 │   812,014 │   768,516 │   643,479 │
+│       maiko │       100,000 │   778,227 │   782,469 │   712,197 │   713,271 │
+│       actix │         1,000 │ 4,072,205 │ 4,182,926 │ 3,710,988 │ 3,411,817 │
+│       actix │        10,000 │ 4,292,594 │ 4,373,233 │ 3,939,233 │ 3,080,245 │
+│       actix │       100,000 │ 4,276,946 │ 4,197,778 │ 3,911,589 │ 3,130,537 │
+│      ractor │         1,000 │ 3,194,561 │ 3,192,353 │ 2,692,416 │ 2,112,884 │
+│      ractor │        10,000 │ 3,012,807 │ 3,013,401 │ 2,571,302 │ 1,688,873 │
+│      ractor │       100,000 │ 3,069,069 │ 2,843,617 │ 2,434,496 │ 1,702,354 │
+╰─────────────┴───────────────┴───────────┴───────────┴───────────┴───────────╯
+```
+
+Unit: messages/sec
+
+### Relative throughput vs Maiko
+
+```text
+╭─────────────┬───────────────┬───────┬────────┬────────┬────────╮
+│   Framework │   N \ Payload │   32B │   256B │   1KiB │   4KiB │
+├─────────────┼───────────────┼───────┼────────┼────────┼────────┤
+│       actix │         1,000 │ 5.00x │  5.09x │  4.80x │  4.74x │
+│       actix │        10,000 │ 5.28x │  5.39x │  5.13x │  4.79x │
+│       actix │       100,000 │ 5.50x │  5.36x │  5.49x │  4.39x │
+│      ractor │         1,000 │ 3.92x │  3.88x │  3.48x │  2.93x │
+│      ractor │        10,000 │ 3.71x │  3.71x │  3.35x │  2.62x │
+│      ractor │       100,000 │ 3.94x │  3.63x │  3.42x │  2.39x │
+╰─────────────┴───────────────┴───────┴────────┴────────┴────────╯
+```
+
+Unit: multiplier (higher is better)
+
+## Reading the results
+
+From the sample run:
+
+- `actix` is the fastest implementation across the full matrix, roughly `4.4x` to `5.5x` faster than Maiko.
+- `ractor` is consistently faster than Maiko as well, roughly `2.4x` to `3.9x` faster in this run.
+- both `actix` and `ractor` degrade as payload size increases, but `ractor` drops off more sharply at `4KiB`.
+- Maiko is the slowest of the three in raw throughput, but it is also the implementation whose benchmark most directly reflects its bounded, blocking pub/sub transport semantics.
+- Maiko should therefore be read here as "brokered event transport with stronger architectural separation", not as "direct actor messaging tuned for maximum throughput".
+
+These numbers should be read as transport benchmark results for the specific benchmark harnesses in this directory, not as universal claims about each framework in all workloads.

--- a/maiko/benches/actor_to_actor_transport_actix.rs
+++ b/maiko/benches/actor_to_actor_transport_actix.rs
@@ -1,0 +1,139 @@
+//! Benchmarks end-to-end Actor -> Actor transport throughput in `actix`.
+//!
+//! Matrix:
+//! - message count: 1_000, 10_000, 100_000
+//! - payload size: 32B, 256B, 1KiB, 4KiB
+//!
+//! Throughput unit is messages/sec.
+//!
+//! Run with:
+//! `cargo bench -p maiko --bench actor_to_actor_transport_actix -- --noplot`
+
+use std::{hint::black_box, time::Duration};
+
+use actix::prelude::*;
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use tokio::{sync::oneshot, time::Instant};
+
+#[derive(Message)]
+#[rtype(result = "()")]
+struct BenchMessage(Vec<u8>);
+
+#[derive(Message)]
+#[rtype(result = "()")]
+struct Start;
+
+/// Benchmark producer actor.
+/// It sends `remaining` payload messages as fast as possible after `Start`.
+struct Producer {
+    consumer: Addr<Consumer>,
+    remaining: usize,
+    payload_template: Vec<u8>,
+}
+
+impl Actor for Producer {
+    type Context = Context<Self>;
+}
+
+impl Handler<Start> for Producer {
+    type Result = ();
+
+    fn handle(&mut self, _message: Start, ctx: &mut Self::Context) -> Self::Result {
+        while self.remaining > 0 {
+            self.consumer
+                .do_send(BenchMessage(self.payload_template.clone()));
+            self.remaining -= 1;
+        }
+        ctx.stop();
+    }
+}
+
+/// Benchmark consumer actor.
+/// It counts received messages and signals completion once `target` is reached.
+struct Consumer {
+    received: usize,
+    target: usize,
+    done_tx: Option<oneshot::Sender<()>>,
+}
+
+impl Actor for Consumer {
+    type Context = Context<Self>;
+}
+
+impl Handler<BenchMessage> for Consumer {
+    type Result = ();
+
+    fn handle(&mut self, message: BenchMessage, ctx: &mut Self::Context) -> Self::Result {
+        black_box(message.0.len());
+        self.received += 1;
+        if self.received == self.target {
+            if let Some(done_tx) = self.done_tx.take() {
+                let _ = done_tx.send(());
+            }
+            ctx.stop();
+        }
+    }
+}
+
+fn run_round(message_count: usize, payload_size: usize) -> Duration {
+    let system = System::new();
+    system.block_on(async move {
+        let (done_tx, done_rx) = oneshot::channel::<()>();
+        let payload_template = vec![0_u8; payload_size];
+
+        let consumer = Consumer {
+            received: 0,
+            target: message_count,
+            done_tx: Some(done_tx),
+        }
+        .start();
+
+        let producer = Producer {
+            consumer,
+            remaining: message_count,
+            payload_template,
+        }
+        .start();
+
+        let start = Instant::now();
+        producer.do_send(Start);
+        done_rx
+            .await
+            .expect("consumer should signal completion for each round");
+        start.elapsed()
+    })
+}
+
+fn bench_actor_to_actor_transport_actix(c: &mut Criterion) {
+    let mut group = c.benchmark_group("actor_to_actor_transport_actix");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_millis(500));
+    group.measurement_time(Duration::from_secs(1));
+
+    let message_counts = [1_000_usize, 10_000, 100_000];
+    let payload_sizes = [32_usize, 256, 1_024, 4_096];
+
+    for &message_count in &message_counts {
+        for &payload_size in &payload_sizes {
+            group.throughput(Throughput::Elements(message_count as u64));
+            group.bench_with_input(
+                BenchmarkId::new(format!("{payload_size}B"), message_count),
+                &(message_count, payload_size),
+                |b, &(message_count, payload_size)| {
+                    b.iter_custom(|iters| {
+                        let mut total = Duration::ZERO;
+                        for _ in 0..iters {
+                            total += run_round(message_count, payload_size);
+                        }
+                        total
+                    });
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_actor_to_actor_transport_actix);
+criterion_main!(benches);

--- a/maiko/benches/actor_to_actor_transport_actix.rs
+++ b/maiko/benches/actor_to_actor_transport_actix.rs
@@ -6,6 +6,10 @@
 //!
 //! Throughput unit is messages/sec.
 //!
+//! Backpressure is implemented at the producer send site via
+//! `Addr::send(...).await`, with the consumer mailbox bounded by
+//! `ctx.set_mailbox_capacity(MAILBOX_CAPACITY)`.
+//!
 //! Run with:
 //! `cargo bench -p maiko --bench actor_to_actor_transport_actix -- --noplot`
 
@@ -14,6 +18,8 @@ use std::{hint::black_box, time::Duration};
 use actix::prelude::*;
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use tokio::{sync::oneshot, time::Instant};
+
+const MAILBOX_CAPACITY: usize = 128;
 
 #[derive(Message)]
 #[rtype(result = "()")]
@@ -36,15 +42,25 @@ impl Actor for Producer {
 }
 
 impl Handler<Start> for Producer {
-    type Result = ();
+    type Result = ResponseActFuture<Self, ()>;
 
-    fn handle(&mut self, _message: Start, ctx: &mut Self::Context) -> Self::Result {
-        while self.remaining > 0 {
-            self.consumer
-                .do_send(BenchMessage(self.payload_template.clone()));
-            self.remaining -= 1;
-        }
-        ctx.stop();
+    fn handle(&mut self, _message: Start, _ctx: &mut Self::Context) -> Self::Result {
+        let consumer = self.consumer.clone();
+        let remaining = self.remaining;
+        let payload_template = self.payload_template.clone();
+
+        Box::pin(
+            async move {
+                for _ in 0..remaining {
+                    consumer
+                        .send(BenchMessage(payload_template.clone()))
+                        .await
+                        .expect("consumer mailbox should stay available");
+                }
+            }
+            .into_actor(self)
+            .map(|_, _actor, ctx| ctx.stop()),
+        )
     }
 }
 
@@ -58,6 +74,10 @@ struct Consumer {
 
 impl Actor for Consumer {
     type Context = Context<Self>;
+
+    fn started(&mut self, ctx: &mut Self::Context) {
+        ctx.set_mailbox_capacity(MAILBOX_CAPACITY);
+    }
 }
 
 impl Handler<BenchMessage> for Consumer {

--- a/maiko/benches/actor_to_actor_transport_maiko.rs
+++ b/maiko/benches/actor_to_actor_transport_maiko.rs
@@ -1,0 +1,204 @@
+//! Benchmarks end-to-end Actor -> Broker -> Actor transport throughput.
+//!
+//! Matrix:
+//! - message count: 1_000, 10_000, 100_000
+//! - payload size: 32B, 256B, 1KiB, 4KiB
+//!
+//! Throughput unit is messages/sec.
+//!
+//! Run with:
+//! `cargo bench -p maiko --bench actor_to_actor_transport_maiko -- --noplot`
+use std::{hint::black_box, time::Duration};
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use maiko::{
+    Actor, Context, Envelope, Event, OverflowPolicy, Result, StepAction, Supervisor, Topic,
+};
+use tokio::{runtime::Builder, sync::oneshot, time::Instant};
+
+#[derive(Debug, Clone)]
+enum BenchEvent {
+    Start,
+    Payload(Vec<u8>),
+}
+
+impl Event for BenchEvent {}
+
+#[derive(Debug, Hash, Eq, PartialEq, Clone, Copy)]
+enum BenchTopic {
+    Control,
+    Payload,
+}
+
+impl Topic<BenchEvent> for BenchTopic {
+    fn from_event(event: &BenchEvent) -> Self {
+        match event {
+            BenchEvent::Start => BenchTopic::Control,
+            BenchEvent::Payload(_) => BenchTopic::Payload,
+        }
+    }
+
+    fn overflow_policy(&self) -> OverflowPolicy {
+        OverflowPolicy::Block
+    }
+}
+
+/// Benchmark producer actor.
+/// It sends `remaining` payload messages as fast as possible in `step`, after `BenchEvent::Start`.
+struct Producer {
+    ctx: Context<BenchEvent>,
+    started: bool,
+    remaining: usize,
+    payload_template: Vec<u8>,
+}
+
+impl Actor for Producer {
+    type Event = BenchEvent;
+
+    async fn handle_event(&mut self, envelope: &Envelope<Self::Event>) -> Result {
+        if let BenchEvent::Start = envelope.event() {
+            self.started = true;
+        }
+        Ok(())
+    }
+
+    async fn step(&mut self) -> Result<StepAction> {
+        if !self.started {
+            return Ok(StepAction::AwaitEvent);
+        }
+
+        if self.remaining == 0 {
+            return Ok(StepAction::Never);
+        }
+
+        while self.remaining > 0 {
+            self.ctx
+                .send(BenchEvent::Payload(self.payload_template.clone()))
+                .await?;
+            self.remaining -= 1;
+        }
+
+        Ok(StepAction::Never)
+    }
+}
+
+/// Benchmark consumer actor.
+/// It counts received messages and signals completion once `target` is reached.
+struct Consumer {
+    received: usize,
+    target: usize,
+    done_tx: Option<oneshot::Sender<()>>,
+}
+
+impl Actor for Consumer {
+    type Event = BenchEvent;
+
+    async fn handle_event(&mut self, envelope: &Envelope<Self::Event>) -> Result {
+        match envelope.event() {
+            BenchEvent::Start => {}
+            BenchEvent::Payload(payload) => {
+                black_box(payload.len());
+            }
+        }
+
+        self.received += 1;
+        if self.received == self.target
+            && let Some(done_tx) = self.done_tx.take()
+        {
+            let _ = done_tx.send(());
+        }
+
+        Ok(())
+    }
+}
+
+async fn run_round(message_count: usize, payload_size: usize) -> Duration {
+    let (done_tx, done_rx) = oneshot::channel::<()>();
+    let mut done_tx = Some(done_tx);
+    let payload_template = vec![0_u8; payload_size];
+
+    let mut supervisor = Supervisor::<BenchEvent, BenchTopic>::default();
+    supervisor
+        .add_actor(
+            "producer",
+            move |ctx| Producer {
+                ctx,
+                started: false,
+                remaining: message_count,
+                payload_template,
+            },
+            [BenchTopic::Control],
+        )
+        .expect("producer registration should succeed");
+
+    supervisor
+        .build_actor("consumer", move |_ctx| Consumer {
+            received: 0,
+            target: message_count,
+            done_tx: done_tx.take(),
+        })
+        .topics(&[BenchTopic::Payload])
+        .with_config(|cfg| cfg.with_max_events_per_tick(message_count))
+        .build()
+        .expect("consumer registration should succeed");
+
+    supervisor.start().await.expect("supervisor should start");
+
+    let start = Instant::now();
+    supervisor
+        .send(BenchEvent::Start)
+        .await
+        .expect("start signal should be delivered");
+    done_rx
+        .await
+        .expect("consumer should signal completion for each round");
+    let elapsed = start.elapsed();
+
+    supervisor
+        .stop()
+        .await
+        .expect("supervisor stop should succeed");
+
+    elapsed
+}
+
+fn bench_actor_to_actor_transport(c: &mut Criterion) {
+    let runtime = Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime should build");
+
+    let mut group = c.benchmark_group("actor_to_actor_transport_maiko");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_millis(500));
+    group.measurement_time(Duration::from_secs(1));
+
+    let message_counts = [1_000_usize, 10_000, 100_000];
+    let payload_sizes = [32_usize, 256, 1_024, 4_096];
+
+    for &message_count in &message_counts {
+        for &payload_size in &payload_sizes {
+            group.throughput(Throughput::Elements(message_count as u64));
+            group.bench_with_input(
+                BenchmarkId::new(format!("{payload_size}B"), message_count),
+                &(message_count, payload_size),
+                |b, &(message_count, payload_size)| {
+                    b.iter_custom(|iters| {
+                        runtime.block_on(async {
+                            let mut total = Duration::ZERO;
+                            for _ in 0..iters {
+                                total += run_round(message_count, payload_size).await;
+                            }
+                            total
+                        })
+                    });
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_actor_to_actor_transport);
+criterion_main!(benches);

--- a/maiko/benches/actor_to_actor_transport_maiko.rs
+++ b/maiko/benches/actor_to_actor_transport_maiko.rs
@@ -6,6 +6,10 @@
 //!
 //! Throughput unit is messages/sec.
 //!
+//! Backpressure is implemented at the producer send site via
+//! `Context::send(...).await`, and at routing time via `OverflowPolicy::Block`
+//! for the payload topic.
+//!
 //! Run with:
 //! `cargo bench -p maiko --bench actor_to_actor_transport_maiko -- --noplot`
 use std::{hint::black_box, time::Duration};
@@ -137,7 +141,7 @@ async fn run_round(message_count: usize, payload_size: usize) -> Duration {
             target: message_count,
             done_tx: done_tx.take(),
         })
-        .topics(&[BenchTopic::Payload])
+        .topics([BenchTopic::Payload])
         .with_config(|cfg| cfg.with_max_events_per_tick(message_count))
         .build()
         .expect("consumer registration should succeed");

--- a/maiko/benches/actor_to_actor_transport_ractor.rs
+++ b/maiko/benches/actor_to_actor_transport_ractor.rs
@@ -1,0 +1,202 @@
+//! Benchmarks end-to-end Actor -> Actor transport throughput in `ractor`.
+//!
+//! Matrix:
+//! - message count: 1_000, 10_000, 100_000
+//! - payload size: 32B, 256B, 1KiB, 4KiB
+//!
+//! Throughput unit is messages/sec.
+//!
+//! Run with:
+//! `cargo bench -p maiko --bench actor_to_actor_transport_ractor -- --noplot`
+
+use std::{hint::black_box, time::Duration};
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use ractor::{Actor, ActorProcessingErr, ActorRef, async_trait};
+use tokio::{runtime::Builder, sync::oneshot, time::Instant};
+
+#[derive(Clone)]
+enum BenchMessage {
+    Payload(Vec<u8>),
+}
+
+enum ProducerMessage {
+    Start,
+}
+
+/// Benchmark consumer actor state.
+struct ConsumerState {
+    received: usize,
+    target: usize,
+    done_tx: Option<oneshot::Sender<()>>,
+}
+
+/// Benchmark consumer actor.
+/// It counts received messages and signals completion once `target` is reached.
+struct Consumer;
+
+#[async_trait]
+impl Actor for Consumer {
+    type Msg = BenchMessage;
+    type State = ConsumerState;
+    type Arguments = (usize, oneshot::Sender<()>);
+
+    async fn pre_start(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        (target, done_tx): Self::Arguments,
+    ) -> Result<Self::State, ActorProcessingErr> {
+        Ok(ConsumerState {
+            received: 0,
+            target,
+            done_tx: Some(done_tx),
+        })
+    }
+
+    async fn handle(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        message: Self::Msg,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        match message {
+            BenchMessage::Payload(payload) => {
+                black_box(payload.len());
+            }
+        }
+
+        state.received += 1;
+        if state.received == state.target
+            && let Some(done_tx) = state.done_tx.take()
+        {
+            let _ = done_tx.send(());
+        }
+
+        Ok(())
+    }
+}
+
+/// Benchmark producer actor.
+/// It sends `remaining` payload messages as fast as possible after `ProducerMessage::Start`.
+struct Producer;
+
+struct ProducerState {
+    consumer: ActorRef<BenchMessage>,
+    remaining: usize,
+    payload_template: Vec<u8>,
+}
+
+#[async_trait]
+impl Actor for Producer {
+    type Msg = ProducerMessage;
+    type State = ProducerState;
+    type Arguments = (ActorRef<BenchMessage>, usize, Vec<u8>);
+
+    async fn pre_start(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        (consumer, remaining, payload_template): Self::Arguments,
+    ) -> Result<Self::State, ActorProcessingErr> {
+        Ok(ProducerState {
+            consumer,
+            remaining,
+            payload_template,
+        })
+    }
+
+    async fn handle(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        message: Self::Msg,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        match message {
+            ProducerMessage::Start => {
+                for _ in 0..state.remaining {
+                    state
+                        .consumer
+                        .send_message(BenchMessage::Payload(state.payload_template.clone()))?;
+                }
+                state.remaining = 0;
+            }
+        }
+        Ok(())
+    }
+}
+
+async fn run_round(message_count: usize, payload_size: usize) -> Duration {
+    let (done_tx, done_rx) = oneshot::channel::<()>();
+    let payload_template = vec![0_u8; payload_size];
+
+    let (consumer_ref, consumer_handle) = Actor::spawn(None, Consumer, (message_count, done_tx))
+        .await
+        .expect("consumer spawn should succeed");
+    let (producer_ref, producer_handle) = Actor::spawn(
+        None,
+        Producer,
+        (consumer_ref.clone(), message_count, payload_template),
+    )
+    .await
+    .expect("producer spawn should succeed");
+
+    let start = Instant::now();
+    producer_ref
+        .send_message(ProducerMessage::Start)
+        .expect("producer should accept start signal");
+    done_rx
+        .await
+        .expect("consumer should signal completion for each round");
+    let elapsed = start.elapsed();
+
+    producer_ref.stop(None);
+    consumer_ref.stop(None);
+    producer_handle
+        .await
+        .expect("producer should terminate without panic");
+    consumer_handle
+        .await
+        .expect("consumer should terminate without panic");
+
+    elapsed
+}
+
+fn bench_actor_to_actor_transport_ractor(c: &mut Criterion) {
+    let runtime = Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime should build");
+
+    let mut group = c.benchmark_group("actor_to_actor_transport_ractor");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_millis(500));
+    group.measurement_time(Duration::from_secs(1));
+
+    let message_counts = [1_000_usize, 10_000, 100_000];
+    let payload_sizes = [32_usize, 256, 1_024, 4_096];
+
+    for &message_count in &message_counts {
+        for &payload_size in &payload_sizes {
+            group.throughput(Throughput::Elements(message_count as u64));
+            group.bench_with_input(
+                BenchmarkId::new(format!("{payload_size}B"), message_count),
+                &(message_count, payload_size),
+                |b, &(message_count, payload_size)| {
+                    b.iter_custom(|iters| {
+                        runtime.block_on(async {
+                            let mut total = Duration::ZERO;
+                            for _ in 0..iters {
+                                total += run_round(message_count, payload_size).await;
+                            }
+                            total
+                        })
+                    });
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_actor_to_actor_transport_ractor);
+criterion_main!(benches);

--- a/maiko/benches/actor_to_actor_transport_ractor.rs
+++ b/maiko/benches/actor_to_actor_transport_ractor.rs
@@ -6,6 +6,9 @@
 //!
 //! Throughput unit is messages/sec.
 //!
+//! This benchmark does not implement an explicit await-based backpressure path;
+//! the producer currently pushes messages with `ActorRef::send_message(...)`.
+//!
 //! Run with:
 //! `cargo bench -p maiko --bench actor_to_actor_transport_ractor -- --noplot`
 

--- a/scripts/bench_a2a_compare.py
+++ b/scripts/bench_a2a_compare.py
@@ -11,7 +11,7 @@ MESSAGE_COUNTS = (1000, 10000, 100000)
 PAYLOAD_SIZES = (32, 256, 1024, 4096)
 PAYLOAD_HEADERS = ("32B", "256B", "1KiB", "4KiB")
 FRAMEWORKS = (
-    ("maiko", "actor_to_actor_transport"),
+    ("maiko", "actor_to_actor_transport_maiko"),
     ("actix", "actor_to_actor_transport_actix"),
     ("ractor", "actor_to_actor_transport_ractor"),
 )

--- a/scripts/bench_a2a_compare.py
+++ b/scripts/bench_a2a_compare.py
@@ -1,0 +1,105 @@
+"""Compare Actor-to-Actor throughput across maiko, actix, and ractor."""
+
+import json
+from pathlib import Path
+from typing import Optional
+
+from tabulate import tabulate
+
+
+MESSAGE_COUNTS = (1000, 10000, 100000)
+PAYLOAD_SIZES = (32, 256, 1024, 4096)
+PAYLOAD_HEADERS = ("32B", "256B", "1KiB", "4KiB")
+FRAMEWORKS = (
+    ("maiko", "actor_to_actor_transport"),
+    ("actix", "actor_to_actor_transport_actix"),
+    ("ractor", "actor_to_actor_transport_ractor"),
+)
+
+
+def load_mps(group: str, messages: int, payload_size: int) -> Optional[int]:
+    path = (
+        Path("target/criterion")
+        / group
+        / f"{payload_size}B"
+        / str(messages)
+        / "new"
+        / "estimates.json"
+    )
+    if not path.exists():
+        return None
+
+    with path.open("r", encoding="utf-8") as f:
+        mean_ns = float(json.load(f)["mean"]["point_estimate"])
+    return round(messages / (mean_ns / 1_000_000_000.0))
+
+
+def fmt_mps(value: Optional[int]) -> str:
+    return "n/a" if value is None else f"{value:,}"
+
+
+def fmt_ratio(value: Optional[float]) -> str:
+    return "n/a" if value is None else f"{value:.2f}x"
+
+
+def build_absolute_table(data: dict[str, dict[int, dict[int, Optional[int]]]]) -> str:
+    rows: list[list[str]] = []
+    for framework, _group in FRAMEWORKS:
+        for messages in MESSAGE_COUNTS:
+            row = [framework, f"{messages:,}"]
+            for payload_size in PAYLOAD_SIZES:
+                row.append(fmt_mps(data[framework][messages][payload_size]))
+            rows.append(row)
+
+    return tabulate(
+        rows,
+        headers=["Framework", "N \\ Payload", *PAYLOAD_HEADERS],
+        tablefmt="rounded_outline",
+        numalign="right",
+        stralign="right",
+    )
+
+
+def build_relative_table(data: dict[str, dict[int, dict[int, Optional[int]]]]) -> str:
+    rows: list[list[str]] = []
+    for framework in ("actix", "ractor"):
+        for messages in MESSAGE_COUNTS:
+            row = [framework, f"{messages:,}"]
+            for payload_size in PAYLOAD_SIZES:
+                base = data["maiko"][messages][payload_size]
+                comp = data[framework][messages][payload_size]
+                ratio = None if base in (None, 0) or comp is None else comp / base
+                row.append(fmt_ratio(ratio))
+            rows.append(row)
+
+    return tabulate(
+        rows,
+        headers=["Framework", "N \\ Payload", *PAYLOAD_HEADERS],
+        tablefmt="rounded_outline",
+        numalign="right",
+        stralign="right",
+    )
+
+
+def main() -> None:
+    data: dict[str, dict[int, dict[int, Optional[int]]]] = {}
+    for framework, group in FRAMEWORKS:
+        data[framework] = {}
+        for messages in MESSAGE_COUNTS:
+            data[framework][messages] = {}
+            for payload_size in PAYLOAD_SIZES:
+                data[framework][messages][payload_size] = load_mps(
+                    group, messages, payload_size
+                )
+
+    print("Absolute throughput")
+    print(build_absolute_table(data))
+    print("\nUnit: messages/sec")
+
+    print("\nRelative throughput vs maiko")
+    print(build_relative_table(data))
+    print("\nUnit: multiplier (higher is better)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_a2a_matrix.py
+++ b/scripts/bench_a2a_matrix.py
@@ -1,0 +1,47 @@
+"""Print Actor-to-Actor throughput matrix from Criterion estimates."""
+
+import json
+from pathlib import Path
+
+from tabulate import tabulate
+
+
+def main() -> None:
+    # Message counts and payload sizes must match the benchmark definition:
+    # maiko/benches/actor_to_actor_transport.rs
+    message_counts = (1000, 10000, 100000)
+    payload_sizes = (32, 256, 1024, 4096)
+    headers = ["N \\ Payload", "32B", "256B", "1KiB", "4KiB"]
+
+    rows = []
+    for n in message_counts:
+        row = [f"{n:,}"]
+        for p in payload_sizes:
+            path = Path(
+                "target/criterion/actor_to_actor_transport"
+            ) / f"{p}B" / str(n) / "new" / "estimates.json"
+            if not path.exists():
+                row.append("n/a")
+                continue
+
+            with path.open("r", encoding="utf-8") as f:
+                mean_ns = float(json.load(f)["mean"]["point_estimate"])
+
+            mps = round(n / (mean_ns / 1_000_000_000.0))
+            row.append(f"{mps:,}")
+        rows.append(row)
+
+    print(
+        tabulate(
+            rows,
+            headers=headers,
+            tablefmt="rounded_outline",
+            numalign="right",
+            stralign="right",
+        )
+    )
+    print("\nUnit: messages/sec")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/pyproject.toml
+++ b/scripts/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "maiko-scripts"
+version = "0.1.0"
+requires-python = ">=3.9"
+dependencies = [
+    "tabulate>=0.9.0",
+]

--- a/scripts/uv.lock
+++ b/scripts/uv.lock
@@ -1,0 +1,43 @@
+version = 1
+revision = 2
+requires-python = ">=3.9"
+resolution-markers = [
+    "python_full_version >= '3.10'",
+    "python_full_version < '3.10'",
+]
+
+[[package]]
+name = "maiko-scripts"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "tabulate", version = "0.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "tabulate", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "tabulate", specifier = ">=0.9.0" }]
+
+[[package]]
+name = "tabulate"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/fe/802052aecb21e3797b8f7902564ab6ea0d60ff8ca23952079064155d1ae1/tabulate-0.9.0.tar.gz", hash = "sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c", size = 81090, upload-time = "2022-10-06T17:21:48.54Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl", hash = "sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f", size = 35252, upload-time = "2022-10-06T17:21:44.262Z" },
+]
+
+[[package]]
+name = "tabulate"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
+]


### PR DESCRIPTION
Add a Maiko **actor-broker-actor** throughput benchmark.
Partially addresses #101.

To run Maiko throughput bench analysis
```bash
just bench-a2a
```

### Remark.

I also added similar benchmarks comparing the triple maiko-actix-ractor. Maiko performs _significantly_ worse. These benches are currently local but I can push them too, if required.

```bash
Absolute throughput
╭─────────────┬───────────────┬───────────┬───────────┬───────────┬───────────╮
│   Framework │   N \ Payload │       32B │      256B │      1KiB │      4KiB │
├─────────────┼───────────────┼───────────┼───────────┼───────────┼───────────┤
│       maiko │         1,000 │   810,106 │   820,823 │   765,626 │   707,549 │
│       maiko │        10,000 │   824,003 │   817,412 │   792,755 │   733,935 │
│       maiko │       100,000 │   824,626 │   809,803 │   801,395 │   695,946 │
│       actix │         1,000 │ 4,516,609 │ 4,683,393 │ 4,075,874 │ 3,358,159 │
│       actix │        10,000 │ 4,746,198 │ 4,701,140 │ 4,244,897 │ 3,256,094 │
│       actix │       100,000 │ 4,662,745 │ 4,699,904 │ 4,257,104 │ 3,466,150 │
│      ractor │         1,000 │ 3,236,237 │ 3,282,361 │ 2,806,116 │ 2,069,979 │
│      ractor │        10,000 │ 3,130,334 │ 3,088,898 │ 2,708,044 │ 2,003,838 │
│      ractor │       100,000 │ 3,047,928 │ 3,027,213 │ 2,684,306 │ 1,826,763 │
╰─────────────┴───────────────┴───────────┴───────────┴───────────┴───────────╯

Unit: messages/sec

Relative throughput vs maiko
╭─────────────┬───────────────┬───────┬────────┬────────┬────────╮
│   Framework │   N \ Payload │   32B │   256B │   1KiB │   4KiB │
├─────────────┼───────────────┼───────┼────────┼────────┼────────┤
│       actix │         1,000 │ 5.58x │  5.71x │  5.32x │  4.75x │
│       actix │        10,000 │ 5.76x │  5.75x │  5.35x │  4.44x │
│       actix │       100,000 │ 5.65x │  5.80x │  5.31x │  4.98x │
│      ractor │         1,000 │ 3.99x │  4.00x │  3.67x │  2.93x │
│      ractor │        10,000 │ 3.80x │  3.78x │  3.42x │  2.73x │
│      ractor │       100,000 │ 3.70x │  3.74x │  3.35x │  2.62x │
╰─────────────┴───────────────┴───────┴────────┴────────┴────────╯
Unit: multiplier (higher is better)
```

### Why

(IMO) Main reasons:
  - Maiko bench measures `Producer -> Broker -> Consumer` with topic routing and envelope handling, not direct actor-to-actor.
  - Maiko uses blocking/backpressure semantics and await on each send.
  - Actix and Ractor benches are direct producer-to-consumer enqueue loops with non-blocking send APIs.

So we are comparing different semantics:

  - Maiko: brokered + backpressure-aware
  - Actix: direct mailbox + backpressure (I created a sort of backpressure but requires checking)
  - Ractor: direct mailbox + no backpressure (internally unbounded mpsc channel)
  
This is an oranges-to-apples situation. Please share your thoughts @ddrcode 