### PR TITLE
Introspection api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,6 +630,7 @@ version = "0.3.1"
 dependencies = [
  "actix",
  "criterion",
+ "dashmap",
  "futures-util",
  "getrandom 0.4.1",
  "maiko-macros",

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -94,6 +94,7 @@ query.delivered_count(&actor_id);
 query.handled_count(&actor_id);
 query.error_count(&actor_id);
 query.queue_depth(&actor_id);
+query.state(&actor_id);
 query.actors();          // snapshot of active actor IDs
 query.stopped_actors();  // snapshot of stopped actor IDs
 ```

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -77,7 +77,7 @@ sup.monitors().add(Tracer).await;
 
 ### ActorMonitor
 
-Tracks actor lifecycle and overflow counts. Clone it to query from any thread:
+Tracks actor lifecycle and per-actor event flow metrics. Clone it to query from any thread:
 
 ```rust
 use maiko::monitors::ActorMonitor;
@@ -89,6 +89,11 @@ sup.monitors().add(monitor).await;
 // Later, from any thread:
 query.is_alive(&actor_id);
 query.overflow_count(&actor_id);
+query.dispatched_count(&actor_id);
+query.delivered_count(&actor_id);
+query.handled_count(&actor_id);
+query.error_count(&actor_id);
+query.queue_depth(&actor_id);
 query.actors();          // snapshot of active actor IDs
 query.stopped_actors();  // snapshot of stopped actor IDs
 ```

--- a/maiko/Cargo.toml
+++ b/maiko/Cargo.toml
@@ -28,6 +28,7 @@ serde        = ["dep:serde", "dep:serde_json"]
 test-harness = ["monitoring"]
 
 [dependencies]
+dashmap      = "6"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 maiko-macros = { version = "=0.3.1", optional = true, path = "../maiko-macros/" }
 serde        = { version = "1.0", features = ["derive", "rc"], optional = true }

--- a/maiko/src/internal/actor_controller.rs
+++ b/maiko/src/internal/actor_controller.rs
@@ -88,8 +88,16 @@ impl<A: Actor, T: Topic<A::Event>> ActorController<A, T> {
                         let _ = step_handler.backoff.take();
                     }
 
+                    #[cfg(feature = "monitoring")]
+                    self.notify_step_enter();
+
                     match self.actor.step().await {
-                        Ok(action) => handle_step_action(action, &mut step_handler).await,
+                        Ok(action) => {
+                            #[cfg(feature = "monitoring")]
+                            self.notify_step_exit(action);
+
+                            handle_step_action(action, &mut step_handler).await
+                        }
                         Err(e) => {
                             #[cfg(feature = "monitoring")]
                             self.notify_error(&e);
@@ -199,6 +207,24 @@ impl<A: Actor, T: Topic<A::Event>> ActorController<A, T> {
                 .send(MonitoringEvent::ActorStopped(self.ctx.actor_id().clone()));
         }
     }
+
+    #[inline]
+    fn notify_step_enter(&self) {
+        if self.monitoring.is_active() {
+            self.monitoring
+                .send(MonitoringEvent::StepEnter(self.ctx.actor_id().clone()));
+        }
+    }
+
+    #[inline]
+    fn notify_step_exit(&self, step_action: StepAction) {
+        if self.monitoring.is_active() {
+            self.monitoring.send(MonitoringEvent::StepExit(
+                step_action,
+                self.ctx.actor_id().clone(),
+            ));
+        }
+    }
 }
 
 #[cfg(all(test, feature = "test-harness"))]
@@ -297,5 +323,110 @@ mod tests {
         sup.stop().await?;
 
         Ok(())
+    }
+}
+
+#[cfg(all(test, feature = "monitoring"))]
+mod monitoring_tests {
+    //! Monitoring-specific regression tests for [`crate::internal::ActorController`].
+    //!
+    //! These cover runtime signals that are only emitted when the
+    //! `monitoring` feature is enabled, such as step enter/exit callbacks.
+
+    use crate::{
+        Actor, ActorId, DefaultTopic, Envelope, Event, StepAction, Subscribe, Supervisor,
+        monitoring::Monitor,
+    };
+    use std::{
+        sync::{Arc, Mutex},
+        time::Duration,
+    };
+    use tokio::time;
+
+    #[derive(Clone, Debug)]
+    struct TestEvent;
+    impl Event for TestEvent {}
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    enum StepRecord {
+        Enter(ActorId),
+        Exit(StepAction, ActorId),
+    }
+
+    struct StepMonitor {
+        records: Arc<Mutex<Vec<StepRecord>>>,
+    }
+
+    impl Monitor<TestEvent, DefaultTopic> for StepMonitor {
+        fn on_step_enter(&self, actor_id: &ActorId) {
+            self.records
+                .lock()
+                .unwrap()
+                .push(StepRecord::Enter(actor_id.clone()));
+        }
+
+        fn on_step_exit(&self, step_action: &StepAction, actor_id: &ActorId) {
+            self.records
+                .lock()
+                .unwrap()
+                .push(StepRecord::Exit(*step_action, actor_id.clone()));
+        }
+    }
+
+    struct BackoffThenAwaitActor {
+        steps: usize,
+    }
+
+    impl Actor for BackoffThenAwaitActor {
+        type Event = TestEvent;
+
+        async fn handle_event(&mut self, _event: &Envelope<Self::Event>) -> crate::Result {
+            Ok(())
+        }
+
+        async fn step(&mut self) -> crate::Result<StepAction> {
+            self.steps += 1;
+            Ok(match self.steps {
+                1 => StepAction::Backoff(Duration::from_millis(1)),
+                _ => StepAction::AwaitEvent,
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn test_monitoring_emits_step_enter_and_exit() -> crate::Result<()> {
+        let mut sup = Supervisor::<TestEvent>::default();
+        let records = Arc::new(Mutex::new(Vec::new()));
+        let handle = sup
+            .monitors()
+            .add(StepMonitor {
+                records: records.clone(),
+            })
+            .await;
+
+        sup.add_actor(
+            "stepper",
+            |_| BackoffThenAwaitActor { steps: 0 },
+            Subscribe::none(),
+        )?;
+        sup.start().await?;
+
+        time::sleep(Duration::from_millis(10)).await;
+        handle.flush(Duration::from_millis(1)).await;
+
+        let stepper = ActorId::new("stepper");
+        let expected = vec![
+            StepRecord::Enter(stepper.clone()),
+            StepRecord::Exit(
+                StepAction::Backoff(Duration::from_millis(1)),
+                stepper.clone(),
+            ),
+            StepRecord::Enter(stepper.clone()),
+            StepRecord::Exit(StepAction::AwaitEvent, stepper),
+        ];
+
+        assert_eq!(*records.lock().unwrap(), expected);
+
+        sup.stop().await
     }
 }

--- a/maiko/src/internal/actor_controller.rs
+++ b/maiko/src/internal/actor_controller.rs
@@ -1,3 +1,4 @@
+use std::future;
 use std::sync::Arc;
 
 use tokio::{
@@ -28,22 +29,46 @@ pub(crate) struct ActorController<A: Actor, T: Topic<A::Event>> {
 
 impl<A: Actor, T: Topic<A::Event>> ActorController<A, T> {
     pub async fn run(&mut self) -> Result {
+        // `select!` decides what should happen next without running actor work
+        // directly inside branch futures. The selected action is executed below
+        // in ordinary sequential code, which keeps borrow scopes simple.
+        enum Next<E> {
+            Continue,
+            Stop,
+            HandleEvent(Arc<Envelope<E>>),
+            RunStep { clear_backoff: bool },
+        }
+
         self.actor.on_start().await?;
         let mut step_handler = StepHandler::default();
         loop {
-            select! {
+            let next = select! {
                 biased;
 
                 cmd_res = self.command_rx.recv() => match cmd_res {
                     Ok(cmd) => match cmd {
-                        Command::StopActor(ref id) if id == self.ctx.actor_id() => break,
-                        Command::StopRuntime => break,
-                        _ => {}
+                        Command::StopActor(ref id) if id == self.ctx.actor_id() => Next::Stop,
+                        Command::StopRuntime => Next::Stop,
+                        _ => Next::Continue,
                     }
-                    Err(e) => return Err(Error::internal(e))
+                    Err(e) => return Err(Error::internal(e)),
                 },
 
-                Some(event) = self.receiver.recv() => {
+                Some(event) = self.receiver.recv() => Next::HandleEvent(event),
+
+                _ = async {
+                    if let Some(backoff_sleep) = step_handler.backoff.as_mut() {
+                        backoff_sleep.as_mut().await;
+                    }
+                }, if step_handler.is_delayed() => Next::RunStep { clear_backoff: true },
+
+                _ = future::ready(()), if step_handler.can_step() => Next::RunStep { clear_backoff: false },
+            };
+
+            match next {
+                Next::Continue => continue,
+                Next::Stop => break,
+                Next::HandleEvent(event) => {
                     self.handle_incoming_event(event).await?;
 
                     let mut cnt = 1;
@@ -58,13 +83,11 @@ impl<A: Actor, T: Topic<A::Event>> ActorController<A, T> {
                         step_handler.pause = StepPause::None;
                     }
                 }
-
-                _ = async {
-                    if let Some(backoff_sleep) = step_handler.backoff.as_mut() {
-                        backoff_sleep.as_mut().await;
+                Next::RunStep { clear_backoff } => {
+                    if clear_backoff {
+                        let _ = step_handler.backoff.take();
                     }
-                }, if step_handler.is_delayed() => {
-                    let _ = step_handler.backoff.take();
+
                     match self.actor.step().await {
                         Ok(action) => handle_step_action(action, &mut step_handler).await,
                         Err(e) => {
@@ -74,20 +97,7 @@ impl<A: Actor, T: Topic<A::Event>> ActorController<A, T> {
                             self.actor.on_error(e)?;
                             step_handler.reset();
                         }
-                     }
-                }
-
-                res = self.actor.step(), if step_handler.can_step() => {
-                     match res {
-                        Ok(action) => handle_step_action(action, &mut step_handler).await,
-                        Err(e) => {
-                            #[cfg(feature = "monitoring")]
-                            self.notify_error(&e);
-
-                            self.actor.on_error(e)?;
-                            step_handler.reset();
-                        }
-                     }
+                    }
                 }
             }
         }

--- a/maiko/src/monitoring/dispatcher.rs
+++ b/maiko/src/monitoring/dispatcher.rs
@@ -163,6 +163,12 @@ impl<E: Event, T: Topic<E>> MonitorDispatcher<E, T> {
             EventHandled(envelope, topic, actor_id) => {
                 self.notify(|m| m.on_event_handled(&envelope, &topic, &actor_id));
             }
+            StepEnter(actor_id) => {
+                self.notify(|m| m.on_step_enter(&actor_id));
+            }
+            StepExit(step_action, actor_id) => {
+                self.notify(|m| m.on_step_exit(&step_action, &actor_id));
+            }
             Overflow(envelope, topic, actor_id, policy) => {
                 self.notify(|m| m.on_overflow(&envelope, &topic, &actor_id, policy));
             }

--- a/maiko/src/monitoring/monitoring_event.rs
+++ b/maiko/src/monitoring/monitoring_event.rs
@@ -1,11 +1,13 @@
 use std::sync::Arc;
 
-use crate::{ActorId, Envelope, OverflowPolicy};
+use crate::{ActorId, Envelope, OverflowPolicy, StepAction};
 
 pub(crate) enum MonitoringEvent<E, T> {
     EventDispatched(Arc<Envelope<E>>, Arc<T>, ActorId),
     EventDelivered(Arc<Envelope<E>>, Arc<T>, ActorId),
     EventHandled(Arc<Envelope<E>>, Arc<T>, ActorId),
+    StepEnter(ActorId),
+    StepExit(StepAction, ActorId),
     Overflow(Arc<Envelope<E>>, Arc<T>, ActorId, OverflowPolicy),
     ActorRegistered(ActorId),
     ActorStopped(ActorId),

--- a/maiko/src/monitors/actor_monitor.rs
+++ b/maiko/src/monitors/actor_monitor.rs
@@ -1,6 +1,7 @@
-use std::collections::{HashMap, HashSet};
 use std::fmt;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, RwLock};
+
+use dashmap::DashMap;
 
 use crate::{ActorId, Envelope, Event, OverflowPolicy, Topic, monitoring::Monitor};
 
@@ -20,13 +21,21 @@ use crate::{ActorId, Envelope, Event, OverflowPolicy, Topic, monitoring::Monitor
 /// ```
 #[derive(Clone)]
 pub struct ActorMonitor {
-    inner: Arc<Mutex<ActorMonitorInner>>,
+    actors: Arc<DashMap<ActorId, RwLock<ActorStats>>>,
 }
 
-struct ActorMonitorInner {
-    active: HashSet<ActorId>,
-    stopped: HashSet<ActorId>,
-    overflow_counts: HashMap<ActorId, usize>,
+struct ActorStats {
+    stopped: bool,
+    overflow_count: usize,
+}
+
+impl ActorStats {
+    fn new() -> Self {
+        Self {
+            stopped: false,
+            overflow_count: 0,
+        }
+    }
 }
 
 impl ActorMonitor {
@@ -34,44 +43,56 @@ impl ActorMonitor {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            inner: Arc::new(Mutex::new(ActorMonitorInner {
-                active: HashSet::new(),
-                stopped: HashSet::new(),
-                overflow_counts: HashMap::new(),
-            })),
+            actors: Arc::new(DashMap::new()),
         }
     }
 
     /// Returns a snapshot of currently active actor IDs.
     pub fn actors(&self) -> Vec<ActorId> {
-        let lock = self.inner.lock().unwrap();
-        lock.active.iter().cloned().collect()
+        self.actors
+            .iter()
+            .filter_map(|entry| {
+                let stats = entry.value().read().unwrap();
+                (!stats.stopped).then(|| entry.key().clone())
+            })
+            .collect()
     }
 
     /// Returns a snapshot of stopped actor IDs.
     pub fn stopped_actors(&self) -> Vec<ActorId> {
-        let lock = self.inner.lock().unwrap();
-        lock.stopped.iter().cloned().collect()
+        self.actors
+            .iter()
+            .filter_map(|entry| {
+                let stats = entry.value().read().unwrap();
+                stats.stopped.then(|| entry.key().clone())
+            })
+            .collect()
     }
 
     /// Returns `true` if the actor is currently active.
     pub fn is_alive(&self, actor: &ActorId) -> bool {
-        let lock = self.inner.lock().unwrap();
-        lock.active.contains(actor)
+        self.actors
+            .get(actor)
+            .map(|entry| !entry.value().read().unwrap().stopped)
+            .unwrap_or(false)
     }
 
     /// Returns `true` if the actor was registered and has since stopped.
     ///
     /// Returns `false` for actors that were never registered or are still active.
     pub fn is_stopped(&self, actor: &ActorId) -> bool {
-        let lock = self.inner.lock().unwrap();
-        lock.stopped.contains(actor)
+        self.actors
+            .get(actor)
+            .map(|entry| entry.value().read().unwrap().stopped)
+            .unwrap_or(false)
     }
 
     /// Returns the number of overflow events observed for this actor.
     pub fn overflow_count(&self, actor: &ActorId) -> usize {
-        let lock = self.inner.lock().unwrap();
-        lock.overflow_counts.get(actor).copied().unwrap_or(0)
+        self.actors
+            .get(actor)
+            .map(|entry| entry.value().read().unwrap().overflow_count)
+            .unwrap_or(0)
     }
 }
 
@@ -81,15 +102,21 @@ where
     T: Topic<E> + Send,
 {
     fn on_actor_registered(&self, actor_id: &ActorId) {
-        let mut lock = self.inner.lock().unwrap();
-        lock.active.insert(actor_id.clone());
-        lock.stopped.remove(actor_id);
+        let entry = self
+            .actors
+            .entry(actor_id.clone())
+            .or_insert_with(|| RwLock::new(ActorStats::new()));
+        let mut stats = entry.write().unwrap();
+        stats.stopped = false;
     }
 
     fn on_actor_stop(&self, actor_id: &ActorId) {
-        let mut lock = self.inner.lock().unwrap();
-        lock.active.remove(actor_id);
-        lock.stopped.insert(actor_id.clone());
+        let entry = self
+            .actors
+            .entry(actor_id.clone())
+            .or_insert_with(|| RwLock::new(ActorStats::new()));
+        let mut stats = entry.write().unwrap();
+        stats.stopped = true;
     }
 
     fn on_overflow(
@@ -99,8 +126,12 @@ where
         receiver: &ActorId,
         _policy: OverflowPolicy,
     ) {
-        let mut lock = self.inner.lock().unwrap();
-        *lock.overflow_counts.entry(receiver.clone()).or_insert(0) += 1;
+        let entry = self
+            .actors
+            .entry(receiver.clone())
+            .or_insert_with(|| RwLock::new(ActorStats::new()));
+        let mut stats = entry.write().unwrap();
+        stats.overflow_count += 1;
     }
 }
 
@@ -112,11 +143,17 @@ impl Default for ActorMonitor {
 
 impl fmt::Debug for ActorMonitor {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let lock = self.inner.lock().unwrap();
+        let active = self.actors().len();
+        let stopped = self.stopped_actors().len();
+        let overflows = self
+            .actors
+            .iter()
+            .filter(|entry| entry.value().read().unwrap().overflow_count > 0)
+            .count();
         f.debug_struct("ActorMonitor")
-            .field("active", &lock.active.len())
-            .field("stopped", &lock.stopped.len())
-            .field("overflows", &lock.overflow_counts.len())
+            .field("active", &active)
+            .field("stopped", &stopped)
+            .field("overflows", &overflows)
             .finish()
     }
 }

--- a/maiko/src/monitors/actor_monitor.rs
+++ b/maiko/src/monitors/actor_monitor.rs
@@ -1,9 +1,27 @@
 use std::fmt;
 use std::sync::{Arc, RwLock};
+use std::time::Duration;
 
 use dashmap::DashMap;
 
-use crate::{ActorId, Envelope, Event, OverflowPolicy, Topic, monitoring::Monitor};
+use crate::{ActorId, Envelope, Event, OverflowPolicy, StepAction, Topic, monitoring::Monitor};
+
+/// Best-effort runtime state derived from lifecycle and `step()` callbacks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ActorState {
+    /// Actor is registered/running without a more specific step-derived state.
+    Active,
+    /// Actor is currently executing `step()`.
+    Stepping,
+    /// Actor returned `StepAction::AwaitEvent`.
+    AwaitingEvent,
+    /// Actor returned `StepAction::Backoff`.
+    BackingOff(Duration),
+    /// Actor returned `StepAction::Never`.
+    StepDisabled,
+    /// Actor stop was observed.
+    Stopped,
+}
 
 /// Monitor that tracks actor lifecycle and per-actor event flow metrics.
 ///
@@ -23,6 +41,7 @@ use crate::{ActorId, Envelope, Event, OverflowPolicy, Topic, monitoring::Monitor
 /// let handled = query.handled_count(&actor_id);
 /// let errors = query.error_count(&actor_id);
 /// let depth = query.queue_depth(&actor_id);
+/// let state = query.state(&actor_id);
 /// ```
 #[derive(Clone)]
 pub struct ActorMonitor {
@@ -31,6 +50,7 @@ pub struct ActorMonitor {
 
 struct ActorStats {
     stopped: bool,
+    step_status: StepStatus,
     dispatched_count: usize,
     delivered_count: usize,
     handled_count: usize,
@@ -38,15 +58,41 @@ struct ActorStats {
     error_count: usize,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StepStatus {
+    /// No `step()` activity has been observed yet.
+    None,
+    /// The actor is currently executing `step()`.
+    InStep,
+    /// The most recent completed `step()` returned this action.
+    Last(StepAction),
+}
+
 impl ActorStats {
     fn new() -> Self {
         Self {
             stopped: false,
+            step_status: StepStatus::None,
             dispatched_count: 0,
             delivered_count: 0,
             handled_count: 0,
             overflow_count: 0,
             error_count: 0,
+        }
+    }
+
+    fn state(&self) -> ActorState {
+        if self.stopped {
+            ActorState::Stopped
+        } else {
+            match self.step_status {
+                StepStatus::None => ActorState::Active,
+                StepStatus::InStep => ActorState::Stepping,
+                StepStatus::Last(StepAction::AwaitEvent) => ActorState::AwaitingEvent,
+                StepStatus::Last(StepAction::Backoff(duration)) => ActorState::BackingOff(duration),
+                StepStatus::Last(StepAction::Never) => ActorState::StepDisabled,
+                StepStatus::Last(StepAction::Continue | StepAction::Yield) => ActorState::Active,
+            }
         }
     }
 }
@@ -153,6 +199,14 @@ impl ActorMonitor {
             })
             .unwrap_or(0)
     }
+
+    /// Returns the best-effort runtime state for this actor.
+    pub fn state(&self, actor: &ActorId) -> Option<ActorState> {
+        self.actors.get(actor).map(|entry| {
+            let stats = entry.value().read().unwrap();
+            stats.state()
+        })
+    }
 }
 
 impl<E, T> Monitor<E, T> for ActorMonitor
@@ -228,6 +282,24 @@ where
         let mut stats = entry.write().unwrap();
         stats.error_count += 1;
     }
+
+    fn on_step_enter(&self, actor_id: &ActorId) {
+        let entry = self
+            .actors
+            .entry(actor_id.clone())
+            .or_insert_with(|| RwLock::new(ActorStats::new()));
+        let mut stats = entry.write().unwrap();
+        stats.step_status = StepStatus::InStep;
+    }
+
+    fn on_step_exit(&self, step_action: &StepAction, actor_id: &ActorId) {
+        let entry = self
+            .actors
+            .entry(actor_id.clone())
+            .or_insert_with(|| RwLock::new(ActorStats::new()));
+        let mut stats = entry.write().unwrap();
+        stats.step_status = StepStatus::Last(*step_action);
+    }
 }
 
 impl Default for ActorMonitor {
@@ -272,6 +344,7 @@ mod tests {
         let m = ActorMonitor::default();
         assert!(m.actors().is_empty());
         assert!(m.stopped_actors().is_empty());
+        assert_eq!(m.state(&make_id("missing")), None);
     }
 
     #[test]
@@ -283,6 +356,7 @@ mod tests {
 
         assert!(monitor.is_alive(&a));
         assert!(monitor.actors().contains(&a));
+        assert_eq!(monitor.state(&a), Some(ActorState::Active));
     }
 
     #[test]
@@ -295,6 +369,7 @@ mod tests {
 
         assert!(!monitor.is_alive(&a));
         assert!(monitor.stopped_actors().contains(&a));
+        assert_eq!(monitor.state(&a), Some(ActorState::Stopped));
     }
 
     #[test]
@@ -367,6 +442,7 @@ mod tests {
         assert_eq!(monitor.dispatched_count(&a), 0);
         assert_eq!(monitor.delivered_count(&a), 1);
         assert_eq!(monitor.queue_depth(&a), 0);
+        assert_eq!(monitor.state(&a), Some(ActorState::Active));
     }
 
     #[test]
@@ -380,6 +456,7 @@ mod tests {
         assert_eq!(monitor.handled_count(&a), 0);
         assert_eq!(monitor.error_count(&a), 0);
         assert_eq!(monitor.queue_depth(&a), 0);
+        assert_eq!(monitor.state(&a), None);
     }
 
     #[test]
@@ -394,5 +471,54 @@ mod tests {
 
         assert!(query.is_alive(&a));
         assert_eq!(query.error_count(&a), 1);
+    }
+
+    #[test]
+    fn state_tracks_step_lifecycle() {
+        let monitor = ActorMonitor::new();
+        let a = make_id("actor-8");
+        let m: &dyn Monitor<TestEvent, DefaultTopic> = &monitor;
+
+        m.on_actor_registered(&a);
+        assert_eq!(monitor.state(&a), Some(ActorState::Active));
+
+        m.on_step_enter(&a);
+        assert_eq!(monitor.state(&a), Some(ActorState::Stepping));
+
+        m.on_step_exit(&StepAction::AwaitEvent, &a);
+        assert_eq!(monitor.state(&a), Some(ActorState::AwaitingEvent));
+
+        m.on_step_enter(&a);
+        m.on_step_exit(&StepAction::Backoff(Duration::from_millis(5)), &a);
+        assert_eq!(
+            monitor.state(&a),
+            Some(ActorState::BackingOff(Duration::from_millis(5)))
+        );
+
+        m.on_step_enter(&a);
+        m.on_step_exit(&StepAction::Never, &a);
+        assert_eq!(monitor.state(&a), Some(ActorState::StepDisabled));
+
+        m.on_step_enter(&a);
+        m.on_step_exit(&StepAction::Continue, &a);
+        assert_eq!(monitor.state(&a), Some(ActorState::Active));
+
+        m.on_step_enter(&a);
+        m.on_step_exit(&StepAction::Yield, &a);
+        assert_eq!(monitor.state(&a), Some(ActorState::Active));
+    }
+
+    #[test]
+    fn stopped_state_overrides_last_step_action() {
+        let monitor = ActorMonitor::new();
+        let a = make_id("actor-9");
+        let m: &dyn Monitor<TestEvent, DefaultTopic> = &monitor;
+
+        m.on_actor_registered(&a);
+        m.on_step_enter(&a);
+        m.on_step_exit(&StepAction::AwaitEvent, &a);
+        m.on_actor_stop(&a);
+
+        assert_eq!(monitor.state(&a), Some(ActorState::Stopped));
     }
 }

--- a/maiko/src/monitors/actor_monitor.rs
+++ b/maiko/src/monitors/actor_monitor.rs
@@ -5,7 +5,7 @@ use dashmap::DashMap;
 
 use crate::{ActorId, Envelope, Event, OverflowPolicy, Topic, monitoring::Monitor};
 
-/// Monitor that tracks actor lifecycle and overflow counts.
+/// Monitor that tracks actor lifecycle and per-actor event flow metrics.
 ///
 /// Register with the supervisor to passively observe actor registration,
 /// shutdown, and overflow events. Query at any time from any thread.
@@ -18,6 +18,11 @@ use crate::{ActorId, Envelope, Event, OverflowPolicy, Topic, monitoring::Monitor
 /// // Later, from any thread:
 /// let alive = query.is_alive(&actor_id);
 /// let overflows = query.overflow_count(&actor_id);
+/// let dispatched = query.dispatched_count(&actor_id);
+/// let delivered = query.delivered_count(&actor_id);
+/// let handled = query.handled_count(&actor_id);
+/// let errors = query.error_count(&actor_id);
+/// let depth = query.queue_depth(&actor_id);
 /// ```
 #[derive(Clone)]
 pub struct ActorMonitor {
@@ -26,14 +31,22 @@ pub struct ActorMonitor {
 
 struct ActorStats {
     stopped: bool,
+    dispatched_count: usize,
+    delivered_count: usize,
+    handled_count: usize,
     overflow_count: usize,
+    error_count: usize,
 }
 
 impl ActorStats {
     fn new() -> Self {
         Self {
             stopped: false,
+            dispatched_count: 0,
+            delivered_count: 0,
+            handled_count: 0,
             overflow_count: 0,
+            error_count: 0,
         }
     }
 }
@@ -94,6 +107,52 @@ impl ActorMonitor {
             .map(|entry| entry.value().read().unwrap().overflow_count)
             .unwrap_or(0)
     }
+
+    /// Returns the number of dispatches observed for this actor.
+    pub fn dispatched_count(&self, actor: &ActorId) -> usize {
+        self.actors
+            .get(actor)
+            .map(|entry| entry.value().read().unwrap().dispatched_count)
+            .unwrap_or(0)
+    }
+
+    /// Returns the number of deliveries observed for this actor.
+    pub fn delivered_count(&self, actor: &ActorId) -> usize {
+        self.actors
+            .get(actor)
+            .map(|entry| entry.value().read().unwrap().delivered_count)
+            .unwrap_or(0)
+    }
+
+    /// Returns the number of handled events observed for this actor.
+    pub fn handled_count(&self, actor: &ActorId) -> usize {
+        self.actors
+            .get(actor)
+            .map(|entry| entry.value().read().unwrap().handled_count)
+            .unwrap_or(0)
+    }
+
+    /// Returns the number of handler errors observed for this actor.
+    pub fn error_count(&self, actor: &ActorId) -> usize {
+        self.actors
+            .get(actor)
+            .map(|entry| entry.value().read().unwrap().error_count)
+            .unwrap_or(0)
+    }
+
+    /// Returns the estimated queue depth for this actor.
+    ///
+    /// This is derived as `dispatched_count - delivered_count` and reflects
+    /// monitor-observed backlog, not authoritative mailbox state.
+    pub fn queue_depth(&self, actor: &ActorId) -> usize {
+        self.actors
+            .get(actor)
+            .map(|entry| {
+                let stats = entry.value().read().unwrap();
+                stats.dispatched_count.saturating_sub(stats.delivered_count)
+            })
+            .unwrap_or(0)
+    }
 }
 
 impl<E, T> Monitor<E, T> for ActorMonitor
@@ -101,6 +160,33 @@ where
     E: Event,
     T: Topic<E> + Send,
 {
+    fn on_event_dispatched(&self, _envelope: &Envelope<E>, _topic: &T, receiver: &ActorId) {
+        let entry = self
+            .actors
+            .entry(receiver.clone())
+            .or_insert_with(|| RwLock::new(ActorStats::new()));
+        let mut stats = entry.write().unwrap();
+        stats.dispatched_count += 1;
+    }
+
+    fn on_event_delivered(&self, _envelope: &Envelope<E>, _topic: &T, receiver: &ActorId) {
+        let entry = self
+            .actors
+            .entry(receiver.clone())
+            .or_insert_with(|| RwLock::new(ActorStats::new()));
+        let mut stats = entry.write().unwrap();
+        stats.delivered_count += 1;
+    }
+
+    fn on_event_handled(&self, _envelope: &Envelope<E>, _topic: &T, receiver: &ActorId) {
+        let entry = self
+            .actors
+            .entry(receiver.clone())
+            .or_insert_with(|| RwLock::new(ActorStats::new()));
+        let mut stats = entry.write().unwrap();
+        stats.handled_count += 1;
+    }
+
     fn on_actor_registered(&self, actor_id: &ActorId) {
         let entry = self
             .actors
@@ -132,6 +218,15 @@ where
             .or_insert_with(|| RwLock::new(ActorStats::new()));
         let mut stats = entry.write().unwrap();
         stats.overflow_count += 1;
+    }
+
+    fn on_error(&self, _err: &str, actor_id: &ActorId) {
+        let entry = self
+            .actors
+            .entry(actor_id.clone())
+            .or_insert_with(|| RwLock::new(ActorStats::new()));
+        let mut stats = entry.write().unwrap();
+        stats.error_count += 1;
     }
 }
 
@@ -236,22 +331,68 @@ mod tests {
     }
 
     #[test]
+    fn flow_metrics_are_counted() {
+        let monitor = ActorMonitor::new();
+        let a = make_id("actor-5");
+        let env = Envelope::new(TestEvent, a.clone());
+        let topic = DefaultTopic;
+        let m: &dyn Monitor<TestEvent, DefaultTopic> = &monitor;
+
+        m.on_event_dispatched(&env, &topic, &a);
+        m.on_event_dispatched(&env, &topic, &a);
+        m.on_event_delivered(&env, &topic, &a);
+        m.on_event_handled(&env, &topic, &a);
+        m.on_error("boom", &a);
+        m.on_error("boom", &a);
+
+        assert_eq!(monitor.dispatched_count(&a), 2);
+        assert_eq!(monitor.delivered_count(&a), 1);
+        assert_eq!(monitor.handled_count(&a), 1);
+        assert_eq!(monitor.error_count(&a), 2);
+        assert_eq!(monitor.overflow_count(&a), 0);
+        assert_eq!(monitor.queue_depth(&a), 1);
+    }
+
+    #[test]
+    fn queue_depth_saturates_at_zero() {
+        let monitor = ActorMonitor::new();
+        let a = make_id("actor-6");
+        let env = Envelope::new(TestEvent, a.clone());
+        let topic = DefaultTopic;
+        let m: &dyn Monitor<TestEvent, DefaultTopic> = &monitor;
+
+        m.on_event_delivered(&env, &topic, &a);
+        m.on_event_handled(&env, &topic, &a);
+
+        assert_eq!(monitor.dispatched_count(&a), 0);
+        assert_eq!(monitor.delivered_count(&a), 1);
+        assert_eq!(monitor.queue_depth(&a), 0);
+    }
+
+    #[test]
     fn unknown_actor_is_not_alive() {
         let monitor = ActorMonitor::new();
         let a = make_id("unknown");
         assert!(!monitor.is_alive(&a));
         assert_eq!(monitor.overflow_count(&a), 0);
+        assert_eq!(monitor.dispatched_count(&a), 0);
+        assert_eq!(monitor.delivered_count(&a), 0);
+        assert_eq!(monitor.handled_count(&a), 0);
+        assert_eq!(monitor.error_count(&a), 0);
+        assert_eq!(monitor.queue_depth(&a), 0);
     }
 
     #[test]
     fn clone_shares_state() {
         let monitor = ActorMonitor::new();
         let query = monitor.clone();
-        let a = make_id("actor-5");
+        let a = make_id("actor-7");
 
         let m: &dyn Monitor<TestEvent, DefaultTopic> = &monitor;
         m.on_actor_registered(&a);
+        m.on_error("boom", &a);
 
         assert!(query.is_alive(&a));
+        assert_eq!(query.error_count(&a), 1);
     }
 }

--- a/maiko/src/monitors/mod.rs
+++ b/maiko/src/monitors/mod.rs
@@ -21,7 +21,7 @@ mod tracer;
 pub use tracer::Tracer;
 
 mod actor_monitor;
-pub use actor_monitor::ActorMonitor;
+pub use actor_monitor::{ActorMonitor, ActorState};
 
 #[cfg(feature = "recorder")]
 mod recorder;

--- a/maiko/src/monitors/mod.rs
+++ b/maiko/src/monitors/mod.rs
@@ -6,7 +6,7 @@
 //! # Available Monitors
 //!
 //! - [`Tracer`] - Logs event lifecycle via `tracing` crate
-//! - [`ActorMonitor`] - Tracks actor lifecycle and overflow counts
+//! - [`ActorMonitor`] - Tracks actor lifecycle and per-actor event flow metrics
 //! - [`Recorder`] - Records events to a JSON Lines file (requires `recorder` feature)
 //!
 //! # Example


### PR DESCRIPTION
This PR improves monitor-based actor introspection #26 

- Consolidates `ActorMonitor` state into per-actor locked stats instead of a single shared structure.
- Expands monitor-derived metrics with dispatch, delivery, handled, error, overflow, and derived queue-depth data.
- Refactors `ActorController`’s `select!` loop so branch selection and work execution are separated, simplifying scoping around `step()` execution. Without this wiring of `on_step_enter`/`on_step_exit` created a lot of borrowing issues.
- Wires the previously unused `on_step_enter` and `on_step_exit` hooks into the runtime.
- Uses those step callbacks in `ActorMonitor` to derive a best-effort actor state from `StepAction`.

Given the current design, this best-effort actor state is the best option we have right now without bloating the code with additional controller-side reporting.